### PR TITLE
SSH mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,23 @@ Your terminal and terminal-code will likely conflict on important shortcuts, mea
 shortcut conflicts you can run `tode --shortcut-setup`, and you will be placed into an interactive wizard that lets you change terminal or terminal-code shortcuts
 so they no longer conflict
 
+
+
 ### How does it work?
 
 terminal-code combines [terminal-browser](https://github.com/zenbu-labs/terminal-browser) (a browser in the terminal) and [code-server](https://github.com/coder/code-server) (VS Code in the browser) to bring VS Code to the terminal. You should look into these projects for more details!
 
+### SSH
+
+The reccomended way to use terminal-code over ssh is running `tode --ssh user@host` on your local machine (where user@host is what you would normally pass to `ssh`).
+
+The alternative is running `tode` directly on the machine you are shh'd into. This will work, but
+requires:
+- every single frame drawn by vscode to be sent over the network
+- all user input to be sent over the network before vscode can react
+- misses out some [extra optimizations](https://sw.kovidgoyal.net/kitty/graphics-protocol/#local-client)
+
+`tode --ssh` improves on this by running only the backend of vscode on the remote machine. The frontend is still running locally on your device, so vscode is able to respond to interactions ~instantly. Any network requests will get proxied over the ssh connection.
 
 ### Windows
 

--- a/src/browserglue.ts
+++ b/src/browserglue.ts
@@ -16,18 +16,10 @@ export function ipcSocketDir(): string {
   return path.join(stateHome, "tode", "ipc");
 }
 
-/** The browser scripts are authored as typechecked functions in src/browser and
- * serialized here with toString(): each written file is the compiled function
- * applied to a JSON ctx, nothing else. That holds because the build target
- * needs no injected helpers and the functions keep the closure-free rule
- * documented on each of them — test/browserglue.test.js runs the strings in a
- * bare vm context so a violation of either fails the tests, not the pane. */
 export function preloadSource(ctx: PreloadCtx): string {
   return `"use strict";\n(${preloadMain.toString()})(${JSON.stringify(ctx)});\n`;
 }
 
-/** terminal-browser requires this file for its side effects and calls nothing,
- * so the serialized function is applied at the module's top level. */
 export function mainScriptSource(ctx: MainCtx): string {
   return `"use strict";\n(${browserMain.toString()})(${JSON.stringify(ctx)});\n`;
 }
@@ -37,12 +29,7 @@ export function writeBrowserScripts(): { preload: string; mainScript: string } {
   const mainScript = path.join(DATA_DIR, "browser-main.js");
   const ctx: MainCtx = {
     socketDir: ipcSocketDir(),
-    // the same file `tode timing` reads; the proxy used to write it from a
-    // beacon route, now the preload's message lands it here
     timingFile: `${CSS_FILE}.timing.json`,
-    /**
-     * i dont see any real reason we need to do this, seems overly abstract 
-     */
     modules: {
       livesync: path.join(__dirname, "livesync.js"),
       generate: path.join(__dirname, "theme", "generate.js"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,8 @@ import { CODE_SERVER_VERSION, ensureCodeServer, narrateFetch } from "./codeserve
 import { installBridge, requestStartupOpen } from "./bridge";
 import { BOOT_AFTER_APPLY, autoApplyShared, shortcutsCommand } from "./shortcuts/wizard";
 import { importCommand } from "./import/command";
+import { runImport } from "./import/run";
+import type { Editor } from "./import/editors";
 import { runOnboarding } from "./onboarding";
 import { parseGoto, runningWindow, sendToExtension } from "./ipc";
 import type { OpenFile } from "./ipc";
@@ -290,6 +292,47 @@ async function openCommand(args: string[]): Promise<number> {
   );
 }
 
+function importProfile(dir: string): void {
+  const editor: Editor = { name: "this machine", userDir: dir, extensionsDir: null, lastUsed: 0 };
+  const report = runImport(editor);
+  const parts: string[] = [];
+  if (report.settings) parts.push(`${report.settings.imported} settings`);
+  if (report.keybindings) parts.push(`${report.keybindings} keybindings`);
+  if (report.snippets.length) parts.push(`${report.snippets.length} snippet files`);
+  if (report.tasks) parts.push("tasks");
+  if (parts.length) process.stdout.write(`imported ${parts.join(", ")}\n`);
+  installExtensions(path.join(dir, "extensions.txt"));
+}
+
+function installExtensions(listFile: string): void {
+  let ids: string[];
+  try {
+    ids = fs.readFileSync(listFile, "utf8").split("\n").map((line) => line.trim()).filter(Boolean);
+  } catch {
+    return;
+  }
+  const have = new Set(installedExtensions().map((id) => id.toLowerCase()));
+  const missing = ids.filter((entry) => !have.has(entry.split("@")[0].toLowerCase()));
+  if (missing.length === 0) return;
+  process.stdout.write(`installing ${missing.length} extensions\n`);
+  for (const id of missing) {
+    if (extensionCommand(["--install-extension", id], true) !== 0) {
+      process.stderr.write(`  could not install ${id}\n`);
+    }
+  }
+  registerThemeExtension();
+}
+
+function installedExtensions(): string[] {
+  const result = spawnSync(
+    codeServerBin(),
+    ["--list-extensions", "--extensions-dir", EXTENSIONS_DIR, "--user-data-dir", path.join(VSCODE_DIR, "user-data")],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
+  if (result.status !== 0 || !result.stdout) return [];
+  return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
 function extensionCommand(args: string[], quiet = false): number {
   const result = spawnSync(
     codeServerBin(),
@@ -498,12 +541,14 @@ async function sshCommand(target: string | undefined, args: string[]): Promise<n
 
 async function serveCommand(args: string[]): Promise<number> {
   const paletteFile = takeFlag(args, "--palette");
+  const importDir = takeFlag(args, "--import");
   const prepare = takeBool(args, "--prepare");
   const requested = args.find((arg) => !arg.startsWith("-"));
   await ensureCodeServer(narrateFetch(`code-server ${CODE_SERVER_VERSION}`));
   const palette = paletteFile
     ? (JSON.parse(fs.readFileSync(paletteFile, "utf8")) as TerminalPalette)
     : (await readPalette()).palette;
+  if (importDir) importProfile(importDir);
   ensureFont();
   installTheme(palette);
   installCss(palette);

--- a/src/main.ts
+++ b/src/main.ts
@@ -294,6 +294,7 @@ async function openCommand(args: string[]): Promise<number> {
 
 function importProfile(dir: string): void {
   const editor: Editor = { name: "this machine", userDir: dir, extensionsDir: null, lastUsed: 0 };
+  process.stdout.write("importing settings\n");
   const report = runImport(editor);
   const parts: string[] = [];
   if (report.settings) parts.push(`${report.settings.imported} settings`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -315,10 +315,9 @@ function installExtensions(listFile: string): void {
   const missing = ids.filter((entry) => !have.has(entry.split("@")[0].toLowerCase()));
   if (missing.length === 0) return;
   process.stdout.write(`installing ${missing.length} extensions\n`);
-  for (const id of missing) {
-    if (extensionCommand(["--install-extension", id], true) !== 0) {
-      process.stderr.write(`  could not install ${id}\n`);
-    }
+  const args = missing.flatMap((id) => ["--install-extension", id]);
+  if (extensionCommand(args) !== 0) {
+    process.stderr.write("  some extensions could not be installed\n");
   }
   registerThemeExtension();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,9 @@ import { Pane, launchBrowser } from "./launch";
 import { resolveRuntime, resolveRuntimeWithProgress } from "./runtime/release";
 import { INSTALL_ROOT } from "./runtime/paths";
 import { skillCommand } from "./skill";
+import { sshForward, sshOpen } from "./ssh";
 import { resolveTarget, workbenchUrl } from "./target";
+import type { TerminalPalette } from "./terminal/osc";
 import { uninstallCommand } from "./uninstall";
 import { upgrade } from "./upgrade";
 import { hex } from "./theme/color";
@@ -122,6 +124,7 @@ Options:
   --size <fraction>     The % a new split will take up (0.2 to 0.95)
   --timing              Report how long each stage of this open took
   --review              Open on the source control panel
+  --ssh <user@host>     Run terminal-code on an ssh server
 
 Commands, each as the first argument:
   --shortcut-setup      Resolve shortcut conflicts between terminal-code and the current terminal
@@ -129,6 +132,7 @@ Commands, each as the first argument:
   --import [editor]     Bring settings, keybindings, snippets and extensions
                         over from vscode compatible editors
   --theme [file]        Set editor theme
+  --serve [path]        Start code server and print its url
   --skill               An agent skill to assist with modifying terminal-code
   --upgrade [--check]   Upgrade terminal-code to the latest version
   --shutdown            Stop all terminal-code activities
@@ -457,16 +461,77 @@ async function upgradeCommand(args: string[]): Promise<number> {
   }
 }
 
+function installedVersion(): string {
+  try {
+    return fs.readFileSync(path.join(INSTALL_ROOT, "VERSION"), "utf8").trim() || "dev";
+  } catch {
+    return "dev";
+  }
+}
+
+const FORWARDED_OVER_SSH = [
+  "--install-extension",
+  "--uninstall-extension",
+  "--list-extensions",
+  "--shutdown",
+  "--upgrade",
+];
+
+async function sshCommand(target: string | undefined, args: string[]): Promise<number> {
+  if (!target || target.startsWith("-")) fail("--ssh needs a value (user@host or an ssh alias)");
+  if (args.some((arg) => FORWARDED_OVER_SSH.includes(arg))) return sshForward(target, args);
+  const split = takeFlag(args, "--split");
+  const size = takeFlag(args, "--size");
+  const unsupported = args.find((arg) => arg.startsWith("-"));
+  if (unsupported) fail(`${unsupported} is not supported with --ssh yet`);
+  if (args.length > 1) fail("--ssh opens one folder or file");
+  const runtime = await resolveRuntimeWithProgress();
+  const { palette } = await readPalette();
+  return sshOpen(runtime, target, {
+    remotePath: args[0],
+    palette,
+    version: installedVersion(),
+    split,
+    size,
+  });
+}
+
+async function serveCommand(args: string[]): Promise<number> {
+  const paletteFile = takeFlag(args, "--palette");
+  const prepare = takeBool(args, "--prepare");
+  const requested = args.find((arg) => !arg.startsWith("-"));
+  await ensureCodeServer(narrateFetch(`code-server ${CODE_SERVER_VERSION}`));
+  const palette = paletteFile
+    ? (JSON.parse(fs.readFileSync(paletteFile, "utf8")) as TerminalPalette)
+    : (await readPalette()).palette;
+  ensureFont();
+  installTheme(palette);
+  installCss(palette);
+  installSettings();
+  setLiveTheme(generateTheme(palette));
+  autoApplyShared();
+  if (prepare) return 0;
+  installBridge(todeCommand());
+  installKeybindings();
+  const server = await ensureServer();
+  const target = resolveTarget(requested, process.cwd());
+  process.stdout.write(`READY ${workbenchUrl(origin(server), target)}\n`);
+  return 0;
+}
+
 async function main(): Promise<number> {
   const args = process.argv.slice(2);
   if (args[0] === "--version" || args[0] === "-v") {
-    let version = "dev";
-    try {
-      version = fs.readFileSync(path.join(INSTALL_ROOT, "VERSION"), "utf8").trim() || "dev";
-    } catch {}
-    process.stdout.write(`${version}\n`);
+    process.stdout.write(`${installedVersion()}\n`);
     return 0;
   }
+  const sshAt = args.indexOf("--ssh");
+  if (sshAt >= 0) {
+    const target = args[sshAt + 1];
+    args.splice(sshAt, 2);
+    return sshCommand(target, args);
+  }
+  if (args[0] === "--serve") return serveCommand(args.slice(1));
   if (args[0] === "--help" || args[0] === "-h") {
     process.stdout.write(HELP);
     return 0;

--- a/src/runtime/release.ts
+++ b/src/runtime/release.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import { BROWSER_HOME, RUNTIME_DIR, VENDOR_DIR } from "./paths";
 
-export const PINNED_VERSION = "main-adc9006";
+export const PINNED_VERSION = "main-2a739b3";
 
 const RELEASE_ORIGIN = process.env.TODE_RELEASE_ORIGIN ?? "https://terminal-browser.sh/install";
 

--- a/src/runtime/release.ts
+++ b/src/runtime/release.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import { BROWSER_HOME, RUNTIME_DIR, VENDOR_DIR } from "./paths";
 
-export const PINNED_VERSION = "ssh-proxy-5ad8cac";
+export const PINNED_VERSION = "main-adc9006";
 
 const RELEASE_ORIGIN = process.env.TODE_RELEASE_ORIGIN ?? "https://terminal-browser.sh/install";
 

--- a/src/runtime/release.ts
+++ b/src/runtime/release.ts
@@ -1,8 +1,4 @@
-/**
- * need to look into how we can make the icon stop popping up
- * 
- * i think thats an electron thing
- */
+
 import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -10,7 +6,7 @@ import path from "node:path";
 
 import { BROWSER_HOME, RUNTIME_DIR, VENDOR_DIR } from "./paths";
 
-export const PINNED_VERSION = "v0.5.8";
+export const PINNED_VERSION = "ssh-proxy-5ad8cac";
 
 const RELEASE_ORIGIN = process.env.TODE_RELEASE_ORIGIN ?? "https://terminal-browser.sh/install";
 
@@ -30,16 +26,12 @@ export interface Release {
 
 export type Source = "override" | "vendored" | "pinned" | "cloned" | "downloaded";
 
-/** The platform-arch pair release tables are keyed by, here and on tode's own
- * release worker. One computation, shared by everything that picks a build. */
 export function targetTriple(): string {
   return `${process.platform === "darwin" ? "darwin" : "linux"}-${
     process.arch === "arm64" ? "arm64" : "x64"
   }`;
 }
 
-/** The copy that ships inside the release. A normal install always resolves
- * here, so the first run costs no download and needs no network. */
 const VENDORED = path.join(VENDOR_DIR, "terminal-browser");
 
 export interface Runtime {

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { writeBrowserScripts } from "./browserglue";
+import { EXTENSIONS_DIR, USER_DIR } from "./profile";
 import { STATE_DIR } from "./runtime/paths";
 import type { Runtime } from "./runtime/release";
 import type { TerminalPalette } from "./terminal/osc";
@@ -73,6 +74,7 @@ function writeBundle(
   write("manifest.json", `${JSON.stringify({ name: "tode" })}\n`);
   write("version", `${version}\n`);
   write("palette.json", `${JSON.stringify(palette)}\n`);
+  stageProfile(dir);
   write(
     "ensure",
     `#!/bin/sh
@@ -97,7 +99,7 @@ fi
     `#!/bin/sh
 set -e
 ./ensure
-"$HOME/.local/bin/tode" --serve --prepare --palette "$(pwd)/palette.json"
+"$HOME/.local/bin/tode" --serve --prepare --palette "$(pwd)/palette.json" --import "$(pwd)/profile"
 `,
     true,
   );
@@ -115,6 +117,38 @@ exec "$HOME/.local/bin/tode" --serve --palette "$here/palette.json"${
     true,
   );
   return dir;
+}
+
+function stageProfile(bundleDir: string): void {
+  const profile = path.join(bundleDir, "profile");
+  fs.mkdirSync(profile, { recursive: true });
+  for (const file of ["settings.json", "keybindings.json", "tasks.json"]) {
+    try {
+      fs.copyFileSync(path.join(USER_DIR, file), path.join(profile, file));
+    } catch {}
+  }
+  try {
+    fs.cpSync(path.join(USER_DIR, "snippets"), path.join(profile, "snippets"), {
+      recursive: true,
+    });
+  } catch {}
+  fs.writeFileSync(path.join(profile, "extensions.txt"), `${extensionIds().join("\n")}\n`);
+}
+
+function extensionIds(): string[] {
+  try {
+    const listed = JSON.parse(fs.readFileSync(path.join(EXTENSIONS_DIR, "extensions.json"), "utf8"));
+    if (!Array.isArray(listed)) return [];
+    return listed
+      .filter((entry) => typeof entry?.identifier?.id === "string")
+      .map((entry) =>
+        typeof entry.version === "string"
+          ? `${entry.identifier.id}@${entry.version}`
+          : entry.identifier.id,
+      );
+  } catch {
+    return [];
+  }
 }
 
 function shellQuote(value: string): string {

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,0 +1,185 @@
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { writeBrowserScripts } from "./browserglue";
+import { STATE_DIR } from "./runtime/paths";
+import type { Runtime } from "./runtime/release";
+import type { TerminalPalette } from "./terminal/osc";
+
+export function sshOpen(
+  runtime: Runtime,
+  target: string,
+  options: {
+    remotePath?: string;
+    palette: TerminalPalette;
+    version: string;
+    split?: string;
+    size?: string;
+  },
+): Promise<number> {
+  const bundle = writeBundle(options.palette, options.version, options.remotePath);
+  const scripts = writeBrowserScripts();
+  const argv = [
+    "open",
+    "--app-mode",
+    "--ssh",
+    target,
+    "--ssh-bundle",
+    bundle,
+    "--ssh-bundle-dir",
+    "${XDG_DATA_HOME:-$HOME/.local/share}/tode/bundles",
+    `--preload=${scripts.preload}`,
+    `--main-script=${scripts.mainScript}`,
+  ];
+  if (options.split) argv.push("--split", options.split);
+  if (options.size) argv.push("--size", options.size);
+  const child = spawn(runtime.bin, argv, { stdio: "inherit" });
+  return new Promise<number>((resolve) => {
+    child.on("error", (error) => {
+      process.stderr.write(`could not start terminal-browser: ${error.message}\n`);
+      resolve(1);
+    });
+    child.on("exit", (code) => resolve(code ?? 0));
+  });
+}
+
+export function sshForward(target: string, args: string[]): number {
+  const { destination, hostArgs } = resolveSshDestination(target);
+  const tode = '"$HOME/.local/bin/tode"';
+  const hint = `tode is not installed on ${destination}, run: tode --ssh ${target}`;
+  const command = [
+    `[ -x ${tode} ] || { echo '${hint}' >&2; exit 127; };`,
+    `exec ${tode}`,
+    ...args.map(shellQuote),
+  ].join(" ");
+  const result = spawnSync("ssh", [...hostArgs, destination, command], { stdio: "inherit" });
+  return result.status ?? 1;
+}
+
+function writeBundle(
+  palette: TerminalPalette,
+  version: string,
+  remotePath: string | undefined,
+): string {
+  const dir = path.join(STATE_DIR, "ssh-bundle");
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.mkdirSync(dir, { recursive: true });
+  const write = (name: string, contents: string, executable = false) => {
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, contents);
+    if (executable) fs.chmodSync(file, 0o755);
+  };
+  write("manifest.json", `${JSON.stringify({ name: "tode" })}\n`);
+  write("version", `${version}\n`);
+  write("palette.json", `${JSON.stringify(palette)}\n`);
+  write(
+    "ensure",
+    `#!/bin/sh
+set -e
+tode="$HOME/.local/bin/tode"
+want="$(cat "$(dirname "$0")/version")"
+have="$("$tode" --version 2>/dev/null || true)"
+if [ "$want" = dev ]; then
+  [ -n "$have" ] || curl -fsSL https://tode.sh/install/dev | bash
+elif [ "$have" != "$want" ]; then
+  curl -fsSL "https://tode.sh/install/v/$want" | bash
+fi
+"$tode" --help 2>/dev/null | grep -q -- --serve || {
+  echo "the tode on this server ($("$tode" --version 2>/dev/null)) does not support --serve" >&2
+  exit 1
+}
+`,
+    true,
+  );
+  write(
+    "setup",
+    `#!/bin/sh
+set -e
+./ensure
+"$HOME/.local/bin/tode" --serve --prepare --palette "$(pwd)/palette.json"
+`,
+    true,
+  );
+  write(
+    "start",
+    `#!/bin/sh
+set -e
+./ensure
+here="$(pwd)"
+cd "$HOME"
+exec "$HOME/.local/bin/tode" --serve --palette "$here/palette.json"${
+      remotePath ? ` ${shellQuote(remotePath)}` : ""
+    }
+`,
+    true,
+  );
+  return dir;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function resolveSshDestination(target: string): { destination: string; hostArgs: string[] } {
+  if (!target.includes("@") && !target.includes(":")) {
+    const alias = shellAlias(target);
+    if (alias) {
+      const parsed = parseSshCommand(alias);
+      if (parsed) return parsed;
+    }
+  }
+  const match = /^([A-Za-z0-9._-]+@)?([A-Za-z0-9._-]+)(:(\d+))?$/.exec(target);
+  if (!match) {
+    throw new Error(`invalid --ssh ${target} (user@host, host, user@host:port, or an ssh alias)`);
+  }
+  return {
+    destination: `${match[1] ?? ""}${match[2]}`,
+    hostArgs: match[4] ? ["-p", match[4]] : [],
+  };
+}
+
+function shellAlias(name: string): string[] | null {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) return null;
+  const shell = process.env.SHELL ?? "/bin/sh";
+  const result = spawnSync(shell, ["-ic", `alias ${name}`], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 5000,
+  });
+  if (result.status !== 0 || !result.stdout) return null;
+  const line = result.stdout.trim().split("\n").pop() ?? "";
+  const eq = line.indexOf("=");
+  if (eq < 0) return null;
+  const tokens = unquote(line.slice(eq + 1).trim())
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!/(^|\/)ssh$/.test(tokens[0] ?? "")) return null;
+  return tokens.slice(1);
+}
+
+function unquote(value: string): string {
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll(`'\\''`, "'");
+  }
+  if (value.startsWith('"') && value.endsWith('"')) return value.slice(1, -1);
+  return value.replaceAll("\\ ", " ");
+}
+
+const SSH_VALUE_FLAGS = new Set(
+  "-B -b -c -D -E -e -F -I -i -J -L -l -m -O -o -P -p -R -S -W -w".split(" "),
+);
+
+function parseSshCommand(tokens: string[]): { destination: string; hostArgs: string[] } | null {
+  const hostArgs: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.startsWith("-")) {
+      hostArgs.push(token);
+      if (SSH_VALUE_FLAGS.has(token) && i + 1 < tokens.length) hostArgs.push(tokens[++i]);
+      continue;
+    }
+    return { destination: token, hostArgs };
+  }
+  return null;
+}

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -122,14 +122,35 @@ function shellQuote(value: string): string {
 }
 
 function resolveSshDestination(target: string): { destination: string; hostArgs: string[] } {
-  if (!target.includes("@") && !target.includes(":")) {
-    const alias = shellAlias(target);
+  const words = target.trim().split(/\s+/).filter(Boolean);
+  if (words.length > 1) {
+    const tokens = words[0] === "ssh" ? words.slice(1) : words;
+    const hostArgs: string[] = [];
+    let found: string | null = null;
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (token.startsWith("-")) {
+        hostArgs.push(token);
+        if (SSH_VALUE_FLAGS.has(token) && i + 1 < tokens.length) hostArgs.push(tokens[++i]);
+        continue;
+      }
+      if (found) {
+        throw new Error(`invalid --ssh ${target} (both ${found} and ${token} look like destinations)`);
+      }
+      found = token;
+    }
+    if (!found) throw new Error(`invalid --ssh ${target} (no destination)`);
+    return { destination: found, hostArgs };
+  }
+  const single = words[0] ?? "";
+  if (!single.includes("@") && !single.includes(":")) {
+    const alias = shellAlias(single);
     if (alias) {
       const parsed = parseSshCommand(alias);
       if (parsed) return parsed;
     }
   }
-  const match = /^([A-Za-z0-9._-]+@)?([A-Za-z0-9._-]+)(:(\d+))?$/.exec(target);
+  const match = /^([A-Za-z0-9._-]+@)?([A-Za-z0-9._-]+)(:(\d+))?$/.exec(single);
   if (!match) {
     throw new Error(`invalid --ssh ${target} (user@host, host, user@host:port, or an ssh alias)`);
   }


### PR DESCRIPTION
This PR introduces a new `--ssh` option for running terminal-code on a remote machine, while running the frontend on your local hardware. The motivation is currently when running terminal-code over ssh it needs to stream all I/O over the ssh connection (all user input and every frame generated is bottlenecked by the network)

To solve this, a new `--ssh` option was implemented inside [terminal-browser](https://github.com/zenbu-labs/terminal-browser) that allows websites on an ssh server to be loaded on a local terminal-browser instance. In this scenario, all user input is handled locally since the website is running on your device, and just the website's network requests go over the network boundary, which in the case of vscode are handled optimistically, so there is no latency for the majority of interactions. 

To get code server running on the remote machine, we use terminal-browser's the new `--ssh-bundle <dir>` option. When passed terminal-browser copies the bundle at the given path from the local machine to the remote machine over SSH. It executes the bundle's `start` script, and then listens for the `READY <url>` log over stdout of the start script. The url parsed is loaded inside the local-terminal browser automatically

### Demo

https://github.com/user-attachments/assets/813c153a-934e-4b21-86d0-6ae15cd2fbce


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-code/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->