### PR TITLE
Serve the workbench with VS Code's own `code serve-web`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Commands, each as the first argument:
 
 ### How does it work?
 
-terminal-code combines [terminal-browser](https://github.com/zenbu-labs/terminal-browser) (a browser in the terminal) and [code-server](https://github.com/coder/code-server) (VS Code in the browser) to bring VS Code to the terminal. You should look into these projects for more details!
+terminal-code combines [terminal-browser](https://github.com/zenbu-labs/terminal-browser) (a browser in the terminal) and [VS Code](https://github.com/microsoft/vscode)'s own web server — the `code serve-web` that ships with the official `code` CLI — to bring the real VS Code to the terminal. You should look into these projects for more details!
 
 
 
@@ -65,7 +65,6 @@ terminal-code combines [terminal-browser](https://github.com/zenbu-labs/terminal
 Your terminal and terminal-code will likely conflict on important shortcuts, meaning sometimes terminal-code will never even receive your key press. To resolve
 shortcut conflicts you can run `tode --shortcut-setup`, and you will be placed into an interactive wizard that lets you change terminal or terminal-code shortcuts
 so they no longer conflict
-
 
 
 ### SSH

--- a/assets/keymaps/vscode-linux.json
+++ b/assets/keymaps/vscode-linux.json
@@ -1,5 +1,5 @@
 {
- "codeServer": "4.132.0",
+ "vscode": "1.132.0",
  "platform": "linux",
  "bindings": [
   {

--- a/assets/keymaps/vscode-mac.json
+++ b/assets/keymaps/vscode-mac.json
@@ -1,5 +1,5 @@
 {
- "codeServer": "4.132.0",
+ "vscode": "1.132.0",
  "platform": "mac",
  "bindings": [
   {

--- a/scripts/generate-keymaps.js
+++ b/scripts/generate-keymaps.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-/* Regenerates assets/keymaps/vscode-<platform>.json from the pinned
-   code-server itself, so the wizard's picture of "chords the editor binds" is
-   derived, never hand-maintained. Run it when CODE_SERVER_VERSION bumps.
+/* Regenerates assets/keymaps/vscode-<platform>.json from VS Code itself, so
+   the wizard's picture of "chords the editor binds" is derived, never
+   hand-maintained. Run it when the bindings VS Code ships change.
 
-   How: code-server starts with a scratch profile holding one tiny extension
+   How: `code serve-web` starts with a scratch profile holding one tiny extension
    that runs "Open Default Keyboard Shortcuts (JSON)" and writes the document
    to disk. The keymap follows the *client* platform, so a headless Chrome
    visits once as itself (macOS) and once wearing the linux user agent. */
@@ -13,8 +13,8 @@ const os = require("os");
 const path = require("path");
 
 const ROOT = path.resolve(__dirname, "..");
-const { CODE_SERVER_VERSION, codeServerRoot, ensureCodeServer, narrateFetch } = require(path.join(ROOT, "dist/codeserver/vendored.js"));
-const { freePort, answering } = require(path.join(ROOT, "dist/codeserver/server.js"));
+const { ensureVscodeCli, narrateFetch } = require(path.join(ROOT, "dist/codeserver/vendored.js"));
+const { freePort, answering, serveWebArgs } = require(path.join(ROOT, "dist/codeserver/server.js"));
 const { parseJsonc } = require(path.join(ROOT, "dist/jsonc.js"));
 
 /* Enough of the devtools protocol to set the page's user agent and send it
@@ -108,6 +108,8 @@ exports.activate = async () => {
       const doc = vscode.window.activeTextEditor && vscode.window.activeTextEditor.document;
       const text = doc ? doc.getText() : "";
       if (text.includes('"key"')) {
+        // the version lands first so a finished dump always has one beside it
+        fs.writeFileSync(out + ".version", vscode.version);
         fs.writeFileSync(out, text);
         return;
       }
@@ -117,14 +119,23 @@ exports.activate = async () => {
 };
 `;
 
-async function codeServerBin() {
-  const bin = path.join(codeServerRoot(), "bin", "code-server");
-  if (!fs.existsSync(bin)) await ensureCodeServer(narrateFetch(`code-server ${CODE_SERVER_VERSION}`));
-  if (!fs.existsSync(bin)) {
-    console.error(`pinned code-server ${CODE_SERVER_VERSION} did not land at ${bin}`);
+async function vscodeCli() {
+  try {
+    return await ensureVscodeCli(narrateFetch("the VS Code cli"));
+  } catch (error) {
+    console.error(`could not fetch the VS Code cli: ${error.message}`);
     process.exit(1);
   }
-  return bin;
+}
+
+/** serve-web keeps the profile under --server-data-dir: data/ for user data,
+ * extensions/ for extensions, which is where scratchProfile() writes. Only the
+ * profile is scratch — --cli-data-dir is left as serveWebArgs has it, so the
+ * dump reuses the server already on this machine instead of pulling another. */
+function scratchServerArgs(port, scratch) {
+  return serveWebArgs(port).map((arg, at, args) =>
+    args[at - 1] === "--server-data-dir" ? scratch : arg,
+  );
 }
 
 function scratchProfile() {
@@ -161,14 +172,8 @@ async function dump(platform) {
   const dumpFile = path.join(scratch, "dump.json");
   const serverPort = await freePort();
   const server = spawn(
-    await codeServerBin(),
-    [
-      "--auth", "none",
-      "--bind-addr", `127.0.0.1:${serverPort}`,
-      "--user-data-dir", path.join(scratch, "data"),
-      "--extensions-dir", path.join(scratch, "extensions"),
-      "--disable-telemetry", "--disable-update-check", "--disable-workspace-trust",
-    ],
+    await vscodeCli(),
+    scratchServerArgs(serverPort, scratch),
     { env: { ...process.env, KEYMAP_DUMP_FILE: dumpFile }, stdio: "ignore" },
   );
   const chromePort = await freePort();
@@ -184,7 +189,7 @@ async function dump(platform) {
     { stdio: "ignore" },
   );
   try {
-    await waitFor(() => answering(serverPort), 30_000, "code-server");
+    await waitFor(() => answering(serverPort), 30_000, "the VS Code server");
     await waitFor(() => answering(chromePort), 15_000, "chrome devtools");
     const url = `http://127.0.0.1:${serverPort}/`;
     // the emulation override lives only as long as the debug session, so the
@@ -208,7 +213,7 @@ async function dump(platform) {
         });
       }
       await session.send("Page.navigate", { url });
-      await waitFor(() => fs.existsSync(dumpFile), 60_000, `the ${platform} keymap dump`);
+      await waitFor(() => fs.existsSync(dumpFile), 10 * 60_000, `the ${platform} keymap dump`);
     } finally {
       session.close();
     }
@@ -216,7 +221,7 @@ async function dump(platform) {
     if (!Array.isArray(bindings) || bindings.length < 100) {
       throw new Error(`the ${platform} dump does not look like a keymap (${bindings?.length} entries)`);
     }
-    return bindings;
+    return { bindings, version: fs.readFileSync(`${dumpFile}.version`, "utf8").trim() };
   } finally {
     chrome.kill("SIGKILL");
     server.kill("SIGTERM");
@@ -232,12 +237,12 @@ async function main() {
   const out = path.join(ROOT, "assets", "keymaps");
   fs.mkdirSync(out, { recursive: true });
   for (const platform of ["mac", "linux"]) {
-    process.stderr.write(`dumping the ${platform} keymap from code-server ${CODE_SERVER_VERSION}\n`);
-    const bindings = await dump(platform);
+    process.stderr.write(`dumping the ${platform} keymap from the VS Code server\n`);
+    const { bindings, version } = await dump(platform);
     const file = path.join(out, `vscode-${platform}.json`);
     fs.writeFileSync(
       file,
-      `${JSON.stringify({ codeServer: CODE_SERVER_VERSION, platform, bindings }, null, 1)}\n`,
+      `${JSON.stringify({ vscode: version, platform, bindings }, null, 1)}\n`,
     );
     process.stderr.write(`  ${bindings.length} bindings -> ${path.relative(ROOT, file)}\n`);
   }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -5,15 +5,8 @@ import type { BridgeCtx } from "./bridge/ctx";
 import { bridgeMain } from "./bridge/extension";
 import type { OpenRequest } from "./ipc";
 import { DATA_DIR } from "./runtime/paths";
-import { EXTENSIONS_DIR, LIVE_THEME_FILE } from "./profile";
-import {
-  IMPORT_DECISION_ID,
-  QUIT_CHORD,
-  QUIT_COMMAND,
-  hintWhen,
-  loadDecisions,
-  quitWhen,
-} from "./shortcuts/store";
+import { EXTENSIONS_DIR, LIVE_THEME_FILE, liveBindings } from "./profile";
+import { IMPORT_DECISION_ID, QUIT_CHORD, loadDecisions } from "./shortcuts/store";
 
 const BRIDGE_ID = "tode.tode-bridge";
 const BRIDGE_VERSION = "1.5.1";
@@ -26,21 +19,7 @@ export function requestStartupOpen(request: Partial<OpenRequest>): void {
 }
 export const BRIDGE_DIR = path.join(EXTENSIONS_DIR, `${BRIDGE_ID}-${BRIDGE_VERSION}`);
 
-/**
- *
- * i need to map out the code this is basically gonna be a giant code review session
- *
- * the obvious question is where is the entrypoint of the program
- * so i can start traversing it
- *
- *
- */
 function manifest(): unknown {
-  const quitBinding = { command: QUIT_COMMAND, key: QUIT_CHORD, when: quitWhen() };
-  const hintBinding =
-    QUIT_CHORD === "ctrl+c"
-      ? []
-      : [{ command: "tode.quitHint", key: "ctrl+c", when: hintWhen() }];
   return {
     name: "tode-bridge",
     displayName: "terminal-code",
@@ -59,12 +38,15 @@ function manifest(): unknown {
       // confirmQuit (the ctrl+c reflex) and quitHint (the redirect toast) are
       // keybinding targets, and a palette full of quit flavours reads as noise
       commands: [{ command: "tode.quit", title: "Quit", category: "terminal-code" }],
-      keybindings: [quitBinding, ...hintBinding],
+      // the browser holds the workbench's user keybindings, so the file tode
+      // writes cannot reach it — the bridge carries the same list in instead
+      keybindings: liveBindings().map(({ key, command, when }) =>
+        when ? { command, key, when } : { command, key },
+      ),
     },
   };
 }
 
-// hm this is complicated, i dont think the decision choice case makes sense
 export function quitHintMessage(): string {
   const choices = loadDecisions()?.choices ?? {};
   const decision = choices[IMPORT_DECISION_ID] ?? choices[QUIT_CHORD];

--- a/src/codeserver/inject.ts
+++ b/src/codeserver/inject.ts
@@ -2,7 +2,9 @@ import fs from "node:fs";
 import http from "node:http";
 import net from "node:net";
 
-/** code-server in front of a proxy that puts tode's css into the workbench page.
+import { parseJsonc } from "../jsonc";
+
+/** The VS Code server in front of a proxy that puts tode's css into the workbench page.
  *
  * The page needs the css before its first paint, and reaching in over the
  * devtools protocol after the fact means a visible flash, so the html is edited
@@ -13,14 +15,63 @@ import net from "node:net";
  * (--open-tabs-in-popup-stack). */
 export const FONT_ROUTE = "/__tode/font.ttf";
 
+/** The workbench in a browser keeps its user data in the browser, not in the
+ * server's --server-data-dir, so a settings file on disk would never be read.
+ * The document carries the embedder's options instead, and configurationDefaults
+ * is the supported way in: tode's settings arrive as defaults on every load,
+ * which is what "tode owns these keys" already meant, and anything the user
+ * sets in the editor still wins. */
+const CONFIG_META = /(<meta\s+id="vscode-workbench-web-configuration"\s+data-settings=")([^"]*)(")/;
+
+const ENTITIES: Record<string, string> = {
+  "&quot;": '"',
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&#39;": "'",
+};
+
+function decodeAttribute(value: string): string {
+  return value.replace(/&quot;|&amp;|&lt;|&gt;|&#39;/g, (entity) => ENTITIES[entity]);
+}
+
+function encodeAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export function withWorkbenchDefaults(html: string, defaults: Record<string, unknown>): string {
+  const found = html.match(CONFIG_META);
+  if (!found) return html;
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(decodeAttribute(found[2])) as Record<string, unknown>;
+  } catch {
+    return html;
+  }
+  const merged = {
+    ...config,
+    // the folder was asked for by name; a prompt in front of it is only in the way
+    enableWorkspaceTrust: false,
+    configurationDefaults: {
+      ...((config.configurationDefaults as Record<string, unknown>) ?? {}),
+      ...defaults,
+    },
+  };
+  return html.replace(CONFIG_META, `$1${encodeAttribute(JSON.stringify(merged))}$3`);
+}
+
 export function createInjector(
   upstreamPort: number,
   cssFile: string,
   fontFile?: string,
   holdMs = 20_000,
+  settingsFile?: string,
 ): http.Server {
-  const upstreamHost = `127.0.0.1:${upstreamPort}`;
-
   const readCss = (): string => {
     try {
       return fs.readFileSync(cssFile, "utf8");
@@ -29,16 +80,23 @@ export function createInjector(
     }
   };
 
-  // code-server checks that a request comes from its own origin, so the
-  // rewritten headers have to say so even though the browser said otherwise
-  const forwardHeaders = (incoming: http.IncomingHttpHeaders, wantsHtml: boolean) => {
-    const headers: http.IncomingHttpHeaders = { ...incoming, host: upstreamHost };
-    for (const name of ["origin", "referer"] as const) {
-      const value = headers[name];
-      if (typeof value === "string") {
-        headers[name] = value.replace(/^https?:\/\/[^/]+/, `http://${upstreamHost}`);
-      }
+  const readDefaults = (): Record<string, unknown> => {
+    if (!settingsFile) return {};
+    try {
+      const parsed = parseJsonc(fs.readFileSync(settingsFile, "utf8"));
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
     }
+  };
+
+  // The browser talks to the injector and the workbench talks to whatever the
+  // host header said, so the client's own host is carried through: one origin
+  // for the document, its resources and its websocket. Rewriting it to the
+  // upstream would leave the page fetching across origins, which the
+  // workbench's own content security policy refuses.
+  const forwardHeaders = (incoming: http.IncomingHttpHeaders, wantsHtml: boolean) => {
+    const headers: http.IncomingHttpHeaders = { ...incoming };
     // an encoded body cannot be edited, so documents are asked for in the clear
     if (wantsHtml) headers["accept-encoding"] = "identity";
     return headers;
@@ -77,7 +135,8 @@ export function createInjector(
         everAnswered = true;
         const type = from.headers["content-type"] ?? "";
         const css = readCss();
-        if (!type.includes("text/html") || !css) {
+        const defaults = readDefaults();
+        if (!type.includes("text/html") || (!css && Object.keys(defaults).length === 0)) {
           response.writeHead(from.statusCode ?? 502, from.headers);
           from.pipe(response);
           return;
@@ -86,10 +145,11 @@ export function createInjector(
         from.on("data", (chunk: Buffer) => chunks.push(chunk));
         from.on("end", () => {
           const body = Buffer.concat(chunks).toString("utf8");
-          const style = `<style id="tode-injected">${css}</style>`;
-          const patched = body.includes("</head>")
+          const style = css ? `<style id="tode-injected">${css}</style>` : "";
+          const styled = body.includes("</head>")
             ? body.replace("</head>", `${style}</head>`)
             : `${style}${body}`;
+          const patched = withWorkbenchDefaults(styled, defaults);
           const out = Buffer.from(patched, "utf8");
           const headers = { ...from.headers, "content-length": String(out.byteLength) };
           delete headers["content-encoding"];
@@ -102,14 +162,14 @@ export function createInjector(
       },
     );
     upstream.on("error", (error: NodeJS.ErrnoException) => {
-      // code-server may still be booting: the browser was started alongside it
+      // the server may still be booting: the browser was started alongside it
       // rather than after it, so the request waits instead of failing
       if (error.code === "ECONNREFUSED" && !everAnswered && Date.now() - started < holdMs) {
         setTimeout(() => server.emit("request", request, response), 60);
         return;
       }
       if (!response.headersSent) response.writeHead(502);
-      response.end("tode: code-server is not answering\n");
+      response.end("tode: the VS Code server is not answering\n");
     });
     request.pipe(upstream);
   });
@@ -133,7 +193,7 @@ export function createInjector(
       client.pipe(target);
       // an upgraded socket allows half open, so a browser going away shows up as
       // "end" and never as "close". Watching only for close would leave the
-      // connection to code-server behind on every reload.
+      // connection to the server behind on every reload.
       const drop = () => {
         target.destroy();
         client.destroy();

--- a/src/codeserver/injector-main.ts
+++ b/src/codeserver/injector-main.ts
@@ -5,12 +5,13 @@ const upstream = Number(process.argv[2]);
 const port = Number(process.argv[3]);
 const cssFile = process.argv[4];
 const fontFile = process.argv[5];
+const settingsFile = process.argv[6];
 
 if (!upstream || !port || !cssFile) {
   process.stderr.write("usage: injector-main <upstreamPort> <port> <cssFile>\n");
   process.exit(1);
 }
 
-createInjector(upstream, cssFile, fontFile).listen(port, "127.0.0.1", () => {
+createInjector(upstream, cssFile, fontFile, undefined, settingsFile).listen(port, "127.0.0.1", () => {
   process.stdout.write(`tode injector ${port} -> ${upstream}\n`);
 });

--- a/src/codeserver/server.ts
+++ b/src/codeserver/server.ts
@@ -4,8 +4,17 @@ import net from "node:net";
 import path from "node:path";
 
 import { DATA_DIR, LOGS_DIR, STATE_DIR } from "../runtime/paths";
-import { CODE_SERVER_VERSION, ensureCodeServer, installedCodeServer, narrateFetch } from "./vendored";
+import {
+  CLI_DATA_DIR,
+  ensureVscodeCli,
+  installedVscodeCli,
+  installedVscodeServer,
+  narrateFetch,
+} from "./vendored";
 
+/** `--server-data-dir`: the real server keeps its user data in <dir>/data and
+ * its extensions in <dir>/extensions, which is the layout src/profile.ts
+ * writes into. */
 const VSCODE_DIR = path.join(DATA_DIR, "vscode");
 export const STATE_FILE = path.join(STATE_DIR, "server.json");
 
@@ -18,13 +27,15 @@ export interface ServerState {
   version: string;
   startedAt: number;
 }
-/**
- * this is odd i would say
- */
-
 export const CSS_FILE = path.join(DATA_DIR, "inject.css");
 // kept apart from the run state, which is cleared on every stop
 export const PORT_FILE = path.join(DATA_DIR, "injector.port");
+
+export const SERVER_LOG = path.join(LOGS_DIR, "vscode-server.log");
+
+/** The same file src/profile.ts writes; named here too so the injector can be
+ * handed it without server.ts importing profile.ts, which imports this. */
+export const SETTINGS_FILE = path.join(VSCODE_DIR, "data", "User", "settings.json");
 
 function fontAsset(): string {
   for (let dir = __dirname; ; dir = path.dirname(dir)) {
@@ -34,10 +45,30 @@ function fontAsset(): string {
   }
 }
 
-export function codeServerBin(): string {
-  const found = installedCodeServer();
+export function vscodeCliBin(): string {
+  const found = installedVscodeCli();
   if (found) return found;
-  throw new Error(`code-server ${CODE_SERVER_VERSION} not found`);
+  throw new Error("the VS Code cli is not fetched yet");
+}
+
+/** How the workbench is served: Microsoft's `code serve-web`, on loopback,
+ * with no connection token because the injector in front of it is the only
+ * thing that ever connects. */
+export function serveWebArgs(port: number): string[] {
+  return [
+    "serve-web",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(port),
+    "--without-connection-token",
+    "--accept-server-license-terms",
+    "--server-data-dir",
+    VSCODE_DIR,
+    "--cli-data-dir",
+    CLI_DATA_DIR,
+    "--disable-telemetry",
+  ];
 }
 
 function readState(): ServerState | null {
@@ -122,51 +153,27 @@ async function startServer(): Promise<ServerState> {
   const existing = await currentServer();
   if (existing) return existing;
 
-  const bin = await ensureCodeServer(narrateFetch(`code-server ${CODE_SERVER_VERSION}`));
+  const bin = await ensureVscodeCli(narrateFetch("the VS Code cli"));
   // asked now, awaited after the injector is up — the version is a detail for
   // `tode daemon status`, not something the boot should stall on
   const version = serverVersion(bin);
   const port = await freePort();
   fs.mkdirSync(LOGS_DIR, { recursive: true });
-  const log = fs.openSync(path.join(LOGS_DIR, "code-server.log"), "a");
-  const child = spawn(
-    bin,
-    [
-      "--auth",
-      "none",
-      "--bind-addr",
-      `127.0.0.1:${port}`,
-      "--user-data-dir",
-      path.join(VSCODE_DIR, "user-data"),
-      "--extensions-dir",
-      path.join(VSCODE_DIR, "extensions"),
-      "--app-name",
-      "tode",
-      "--disable-telemetry",
-      "--disable-update-check",
-      "--disable-workspace-trust",
-      "--disable-getting-started-override",
-      "--ignore-last-opened",
-    ],
-    {
-      detached: true,
-      stdio: ["ignore", log, log],
-      env: {
-        ...process.env,
-        EXTENSIONS_GALLERY: JSON.stringify({
-          serviceUrl: "https://marketplace.visualstudio.com/_apis/public/gallery",
-          itemUrl: "https://marketplace.visualstudio.com/items",
-          cacheUrl: "https://vscode.blob.core.windows.net/gallery/index",
-          controlUrl: "",
-        }),
-      },
-    },
-  );
+  const log = fs.openSync(SERVER_LOG, "a");
+  // serve-web only pulls the server down when a page is asked for, so a first
+  // run is a long quiet moment unless it says what it is doing
+  if (!installedVscodeServer()) {
+    process.stderr.write("tode: fetching the VS Code server, the first window waits on it\n");
+  }
+  const child = spawn(bin, serveWebArgs(port), {
+    detached: true,
+    stdio: ["ignore", log, log],
+  });
   child.unref();
-  if (!child.pid) throw new Error("could not start code-server");
+  if (!child.pid) throw new Error("could not start code serve-web");
 
   const injector = await startInjector(port, log);
-  void codeServerReady(port, child.pid).then((up) => {
+  void serveWebReady(port, child.pid).then((up) => {
     if (up) void warmUp(injector.port);
   });
   const state = {
@@ -181,7 +188,7 @@ async function startServer(): Promise<ServerState> {
   return state;
 }
 
-async function codeServerReady(port: number, pid: number): Promise<boolean> {
+async function serveWebReady(port: number, pid: number): Promise<boolean> {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     if (await answering(port)) return true;
@@ -189,6 +196,29 @@ async function codeServerReady(port: number, pid: number): Promise<boolean> {
     await sleep(60);
   }
   return false;
+}
+
+/** The server itself only lands on disk once serve-web has been asked for a
+ * page, so anything that needs the binary — installing an extension, listing
+ * them — starts the server and waits for the download to finish. */
+export async function ensureVscodeServer(): Promise<string> {
+  const already = installedVscodeServer();
+  if (already) return already;
+
+  const state = await ensureServer();
+  await fetch(origin(state), { headers: { accept: "text/html" } }).catch(() => null);
+  const deadline = Date.now() + 10 * 60_000;
+  let announced = false;
+  while (Date.now() < deadline) {
+    const bin = installedVscodeServer();
+    if (bin) return bin;
+    if (!announced) {
+      process.stderr.write("tode: fetching the VS Code server\n");
+      announced = true;
+    }
+    await sleep(500);
+  }
+  throw new Error(`the VS Code server did not download — see ${SERVER_LOG}`);
 }
 
 async function injectorPort(portFile: string): Promise<number> {
@@ -216,13 +246,13 @@ export async function startInjector(
   portFile = PORT_FILE,
 ): Promise<{ pid: number; port: number }> {
   const port = await injectorPort(portFile);
-  // interesting? a script?
   const script = path.join(__dirname, "injector-main.js");
   const font = fontAsset();
-  const child = spawn(process.execPath, [script, String(upstream), String(port), CSS_FILE, font], {
-    detached: true,
-    stdio: ["ignore", log, log],
-  });
+  const child = spawn(
+    process.execPath,
+    [script, String(upstream), String(port), CSS_FILE, font, SETTINGS_FILE],
+    { detached: true, stdio: ["ignore", log, log] },
+  );
   child.unref();
   if (!child.pid) throw new Error("could not start the css injector");
   const deadline = Date.now() + 10_000;

--- a/src/codeserver/vendored.ts
+++ b/src/codeserver/vendored.ts
@@ -1,48 +1,83 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 import { DATA_DIR } from "../runtime/paths";
-import { fetchVerified, targetTriple, unpack } from "../runtime/release";
+import { fetchVerified, targetTriple } from "../runtime/release";
 
-/** The code-server build tode is written against. The workbench tode injects
- * into is version-specific, so it pins rather than taking whatever happens to
- * be installed. Bump the version and the hashes together — they come from the
- * digests GitHub publishes on the release assets. */
-export const CODE_SERVER_VERSION = "4.132.0";
+/** Microsoft's own `code` cli — the one that ships with VS Code — is what tode
+ * serves the workbench with: `code serve-web` fetches the real VS Code server
+ * and puts the workbench on a port. Nothing here is a fork, so there is no
+ * build for tode to pin against: the update service names the current stable
+ * cli, and the sha256 it reports is what the download is checked against. */
+export const VSCODE_QUALITY = "stable";
 
-/** tode target -> the name code-server releases under, and the sha256 GitHub
- * reports for that asset. */
-const CODE_SERVER_BUILDS: Record<string, { asset: string; sha256: string; size: number }> = {
-  "darwin-arm64": {
-    asset: "macos-arm64",
-    sha256: "449814f6637faaf9b68544f7bce560f5ec500de688815d5c7f9afa7a51577992",
-    size: 211120710,
-  },
-  "linux-x64": {
-    asset: "linux-amd64",
-    sha256: "a38d26f4cb81f768feddff79e2937fd3f39c83d3da8be3da7225e1087e62e4ed",
-    size: 238758593,
-  },
-  "linux-arm64": {
-    asset: "linux-arm64",
-    sha256: "ade569a677d1c04ee66ef153382b7e15bf261f955407663c7ddc6b87f9ee29fc",
-    size: 232503176,
-  },
+function updateOrigin(): string {
+  return process.env.TODE_VSCODE_UPDATE_ORIGIN ?? "https://update.code.visualstudio.com";
+}
+
+/** tode target -> the cli build the update service publishes for it. */
+const CLI_TARGETS: Record<string, string> = {
+  "darwin-arm64": "cli-darwin-arm64",
+  "linux-x64": "cli-linux-x64",
+  "linux-arm64": "cli-linux-arm64",
 };
 
-export function codeServerRoot(version = CODE_SERVER_VERSION): string {
-  return path.join(DATA_DIR, "code-server", version);
+/** unpacked `code` clis, one directory per version */
+export const CLI_DIR = path.join(DATA_DIR, "vscode-cli");
+
+/** the cli's own store — `serve-web` keeps the servers it downloads here,
+ * clear of a ~/.vscode-cli the user may be running tunnels out of */
+export const CLI_DATA_DIR = path.join(DATA_DIR, "vscode-cli-data");
+
+export interface CliRelease {
+  /** the product version, e.g. 1.105.2 */
+  version: string;
+  /** the vscode commit it was built from */
+  commit: string;
+  url: string;
+  sha256: string;
+  size: number;
 }
 
-function binAt(root: string): string | null {
-  const bin = path.join(root, "bin", "code-server");
-  return fs.existsSync(bin) ? bin : null;
+export function cliRoot(version: string): string {
+  return path.join(CLI_DIR, version);
 }
 
-export function installedCodeServer(): string | null {
-  const configured = process.env.TODE_CODE_SERVER;
+/** The newest of the binaries a directory of versioned trees holds, ignoring
+ * the `<name>.staging` and `<name>.unpacking` trees a half-done download
+ * leaves behind. */
+function newestBin(dir: string, binIn: (entry: string) => string): string | null {
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return null;
+  }
+  const found: { bin: string; at: number }[] = [];
+  for (const entry of entries) {
+    if (entry.includes(".staging") || entry.includes(".unpacking")) continue;
+    const bin = binIn(entry);
+    try {
+      found.push({ bin, at: fs.statSync(bin).mtimeMs });
+    } catch {}
+  }
+  found.sort((a, b) => b.at - a.at);
+  return found[0]?.bin ?? null;
+}
+
+export function installedVscodeCli(): string | null {
+  const configured = process.env.TODE_VSCODE_CLI;
   if (configured) return configured;
-  return binAt(codeServerRoot());
+  return newestBin(CLI_DIR, (entry) => path.join(CLI_DIR, entry, "code"));
+}
+
+/** The VS Code server `code serve-web` downloaded, once it has served a page.
+ * It is the binary the workbench actually runs on, and the one extensions have
+ * to be installed with — the cli's own `code ext` drives a desktop install. */
+export function installedVscodeServer(): string | null {
+  const cache = path.join(CLI_DATA_DIR, "serve-web");
+  return newestBin(cache, (entry) => path.join(cache, entry, "bin", "code-server"));
 }
 
 export function narrateFetch(label: string): (fraction: number) => void {
@@ -60,23 +95,82 @@ export function narrateFetch(label: string): (fraction: number) => void {
   };
 }
 
-export async function ensureCodeServer(
-  onProgress?: (fraction: number) => void,
-): Promise<string> {
-  const already = installedCodeServer();
+/** The version names a directory under CLI_DIR, so it has to be a plain name.
+ * The update service is Microsoft's over https, but a version is the one field
+ * here that becomes a path, and a "../.." in it would put the download
+ * somewhere else entirely. */
+function safeVersion(version: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(version) || version.includes("..")) {
+    throw new Error(`the VS Code update service named a version tode will not use as a path: ${version}`);
+  }
+  return version;
+}
+
+/** What the update service serves for this machine right now. The document is
+ * the one VS Code updates itself from, so the digest in it is the digest the
+ * download has to have. */
+export async function latestCli(): Promise<CliRelease> {
+  const target = CLI_TARGETS[targetTriple()];
+  if (!target) throw new Error(`no VS Code cli build for ${targetTriple()}`);
+  const url = `${updateOrigin()}/api/update/${target}/${VSCODE_QUALITY}/latest`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`the VS Code update service did not answer (${response.status} from ${url})`);
+  }
+  const release = (await response.json()) as {
+    url?: string;
+    version?: string;
+    productVersion?: string;
+    sha256hash?: string;
+    size?: number;
+  };
+  if (!release.url || !release.version || !release.sha256hash) {
+    throw new Error(`the VS Code update service did not name a ${target} build to download`);
+  }
+  return {
+    version: safeVersion(release.productVersion ?? release.version),
+    commit: release.version,
+    url: release.url,
+    sha256: release.sha256hash,
+    size: release.size ?? 0,
+  };
+}
+
+/** The cli comes as a gzipped tarball on linux and a zip on macos, each of
+ * them the single `code` binary. */
+function unpackCli(archive: string, root: string) {
+  const staging = `${root}.unpacking`;
+  fs.rmSync(staging, { recursive: true, force: true });
+  fs.mkdirSync(staging, { recursive: true });
+  const head = Buffer.alloc(2);
+  const handle = fs.openSync(archive, "r");
+  try {
+    fs.readSync(handle, head, 0, 2, 0);
+  } finally {
+    fs.closeSync(handle);
+  }
+  const gzipped = head[0] === 0x1f && head[1] === 0x8b;
+  if (gzipped) execFileSync("tar", ["-xzf", archive, "-C", staging]);
+  else execFileSync("unzip", ["-q", "-o", archive, "-d", staging]);
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(root), { recursive: true });
+  fs.renameSync(staging, root);
+}
+
+export async function ensureVscodeCli(onProgress?: (fraction: number) => void): Promise<string> {
+  const already = installedVscodeCli();
   if (already) return already;
 
-  const build = CODE_SERVER_BUILDS[targetTriple()];
-  if (!build) throw new Error(`no pinned code-server build for ${targetTriple()}`);
-  const url =
-    `https://github.com/coder/code-server/releases/download/` +
-    `v${CODE_SERVER_VERSION}/code-server-${CODE_SERVER_VERSION}-${build.asset}.tar.gz`;
-  const root = codeServerRoot();
-  const tarball = `${root}.tar.gz`;
-  await fetchVerified(url, build.sha256, build.size, tarball, onProgress);
-  unpack(tarball, root);
-  fs.rmSync(tarball, { force: true });
-  const bin = binAt(root);
-  if (!bin) throw new Error(`unpacked code-server ${CODE_SERVER_VERSION} but it has no bin/code-server`);
+  const release = await latestCli();
+  const root = cliRoot(release.version);
+  const archive = `${root}.download`;
+  await fetchVerified(release.url, release.sha256, release.size, archive, onProgress);
+  unpackCli(archive, root);
+  fs.rmSync(archive, { force: true });
+  const bin = path.join(root, "code");
+  if (!fs.existsSync(bin)) {
+    throw new Error(`unpacked the VS Code cli ${release.version} but it holds no code binary`);
+  }
+  fs.chmodSync(bin, 0o755);
   return bin;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,12 @@ import path from "node:path";
 
 import {
   CSS_FILE,
-  codeServerBin,
   ensureServer,
+  ensureVscodeServer,
   origin,
   stopServer,
 } from "./codeserver/server";
-import { CODE_SERVER_VERSION, ensureCodeServer, narrateFetch } from "./codeserver/vendored";
+import { ensureVscodeCli, narrateFetch } from "./codeserver/vendored";
 import { installBridge, requestStartupOpen } from "./bridge";
 import { BOOT_AFTER_APPLY, autoApplyShared, shortcutsCommand } from "./shortcuts/wizard";
 import { importCommand } from "./import/command";
@@ -43,7 +43,6 @@ import { upgrade } from "./upgrade";
 import { hex } from "./theme/color";
 import { generateTheme, semanticColors } from "./theme/generate";
 
-// hm? does it ever get installed at home dir local?
 function shimPath(): string {
   const binHome = process.env.XDG_BIN_HOME ?? path.join(os.homedir(), ".local", "bin");
   return path.join(binHome, "tode");
@@ -166,8 +165,8 @@ const IGNORED_WITH_VALUE: string[] = [
 ];
 
 const UNSUPPORTED: [string, string][] = [
-  ["--disable-extensions", "extensions are per code-server, not per window"],
-  ["--disable-extension", "extensions are per code-server, not per window"],
+  ["--disable-extensions", "extensions are per server, not per window"],
+  ["--disable-extension", "extensions are per server, not per window"],
 ];
 
 function dropIgnored(args: string[]): void {
@@ -249,7 +248,7 @@ async function openCommand(args: string[]): Promise<number> {
   const target = wanted[0] ?? resolveTarget(undefined, process.cwd());
   const runtime = await resolveRuntimeWithProgress();
   done("runtime");
-  await ensureCodeServer(narrateFetch(`code-server ${CODE_SERVER_VERSION}`));
+  await ensureVscodeCli(narrateFetch("the VS Code cli"));
   const { palette } = await readPalette();
   ensureFont();
   installTheme(palette);
@@ -265,7 +264,7 @@ async function openCommand(args: string[]): Promise<number> {
     installBridge(todeCommand());
     installKeybindings();
     const server = await ensureServer();
-    done("code-server");
+    done("vscode");
     const startupFiles = files.filter((file) => file.line !== undefined || file.path !== target.file);
     if (review || startupFiles.length > 0 || pair.length > 0) {
       requestStartupOpen({
@@ -292,7 +291,7 @@ async function openCommand(args: string[]): Promise<number> {
   );
 }
 
-function importProfile(dir: string): void {
+async function importProfile(dir: string): Promise<void> {
   const editor: Editor = { name: "this machine", userDir: dir, extensionsDir: null, lastUsed: 0 };
   process.stdout.write("importing settings\n");
   const report = runImport(editor);
@@ -302,57 +301,65 @@ function importProfile(dir: string): void {
   if (report.snippets.length) parts.push(`${report.snippets.length} snippet files`);
   if (report.tasks) parts.push("tasks");
   if (parts.length) process.stdout.write(`imported ${parts.join(", ")}\n`);
-  installExtensions(path.join(dir, "extensions.txt"));
+  await installExtensions(path.join(dir, "extensions.txt"));
 }
 
-function installExtensions(listFile: string): void {
+async function installExtensions(listFile: string): Promise<void> {
   let ids: string[];
   try {
     ids = fs.readFileSync(listFile, "utf8").split("\n").map((line) => line.trim()).filter(Boolean);
   } catch {
     return;
   }
-  const have = new Set(installedExtensions().map((id) => id.toLowerCase()));
+  const have = new Set((await installedExtensions()).map((id) => id.toLowerCase()));
   const missing = ids.filter((entry) => !have.has(entry.split("@")[0].toLowerCase()));
   if (missing.length === 0) return;
   process.stdout.write(`installing ${missing.length} extensions\n`);
   const args = missing.flatMap((id) => ["--install-extension", id]);
-  if (extensionCommand(args) !== 0) {
+  if ((await extensionCommand(args)) !== 0) {
     process.stderr.write("  some extensions could not be installed\n");
   }
   registerThemeExtension();
 }
 
-function installedExtensions(): string[] {
+function installedExtensions(): Promise<string[]> {
+  return extensionOutput(["--list-extensions"]);
+}
+
+/** Extensions are managed by the VS Code server itself — the cli's own
+ * `code --install-extension` drives a desktop install, and there isn't one
+ * here. The server binary only exists once serve-web has fetched it. */
+async function extensionCommand(args: string[], quiet = false): Promise<number> {
   const result = spawnSync(
-    codeServerBin(),
-    ["--list-extensions", "--extensions-dir", EXTENSIONS_DIR, "--user-data-dir", path.join(VSCODE_DIR, "user-data")],
+    await ensureVscodeServer(),
+    [...args, "--server-data-dir", VSCODE_DIR, "--extensions-dir", EXTENSIONS_DIR],
+    { stdio: quiet ? ["ignore", "inherit", "ignore"] : "inherit" },
+  );
+  return result.status ?? 1;
+}
+
+/** The same server binary, but with stdout captured rather than inherited. */
+async function extensionOutput(args: string[]): Promise<string[]> {
+  const result = spawnSync(
+    await ensureVscodeServer(),
+    [...args, "--server-data-dir", VSCODE_DIR, "--extensions-dir", EXTENSIONS_DIR],
     { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
   );
   if (result.status !== 0 || !result.stdout) return [];
   return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
 }
 
-function extensionCommand(args: string[], quiet = false): number {
-  const result = spawnSync(
-    codeServerBin(),
-    [...args, "--extensions-dir", EXTENSIONS_DIR, "--user-data-dir", path.join(VSCODE_DIR, "user-data")],
-    { stdio: quiet ? ["ignore", "inherit", "ignore"] : "inherit" },
-  );
-  return result.status ?? 1;
-}
-
-function listExtensions(withVersions: boolean): number {
+function listExtensions(withVersions: boolean): Promise<number> {
   return extensionCommand(withVersions ? ["--list-extensions", "--show-versions"] : ["--list-extensions"], true);
 }
 
-function manageExtensions(install: string[], remove: string[]): number {
+async function manageExtensions(install: string[], remove: string[]): Promise<number> {
   for (const id of remove) {
-    const code = extensionCommand(["--uninstall-extension", id]);
+    const code = await extensionCommand(["--uninstall-extension", id]);
     if (code !== 0) return code;
   }
   for (const id of install) {
-    const code = extensionCommand(["--install-extension", id]);
+    const code = await extensionCommand(["--install-extension", id]);
     if (code !== 0) return code;
   }
   registerThemeExtension();
@@ -544,11 +551,11 @@ async function serveCommand(args: string[]): Promise<number> {
   const importDir = takeFlag(args, "--import");
   const prepare = takeBool(args, "--prepare");
   const requested = args.find((arg) => !arg.startsWith("-"));
-  await ensureCodeServer(narrateFetch(`code-server ${CODE_SERVER_VERSION}`));
+  await ensureVscodeCli(narrateFetch("the VS Code cli"));
   const palette = paletteFile
     ? (JSON.parse(fs.readFileSync(paletteFile, "utf8")) as TerminalPalette)
     : (await readPalette()).palette;
-  if (importDir) importProfile(importDir);
+  if (importDir) await importProfile(importDir);
   ensureFont();
   installTheme(palette);
   installCss(palette);

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -19,12 +19,33 @@ import {
 } from "./theme/generate";
 
 export const VSCODE_DIR = path.join(DATA_DIR, "vscode");
-export const USER_DIR = path.join(VSCODE_DIR, "user-data", "User");
+/** `code serve-web --server-data-dir VSCODE_DIR` puts the profile here; the
+ * server derives it itself and ignores a --user-data-dir. */
+export const USER_DIR = path.join(VSCODE_DIR, "data", "User");
 export const EXTENSIONS_DIR = path.join(VSCODE_DIR, "extensions");
 export const THEME_EXTENSION_ID = "tode.tode-theme";
 
 function themeExtensionDir(fingerprint: string): string {
   return path.join(EXTENSIONS_DIR, `${THEME_EXTENSION_ID}-${fingerprint}`);
+}
+
+/** An install from the code-server days keeps its profile in user-data/; the
+ * real server reads data/. Carrying it over once keeps settings, history and
+ * state across the switch. */
+export function adoptServerLayout(): void {
+  const old = path.join(VSCODE_DIR, "user-data");
+  const current = path.join(VSCODE_DIR, "data");
+  if (!fs.existsSync(old) || fs.existsSync(current)) return;
+  try {
+    fs.renameSync(old, current);
+  } catch (error) {
+    // the open carries on with an empty profile rather than failing, but a
+    // silent one would look like the settings simply vanished
+    process.stderr.write(
+      `tode: could not move the profile from ${old} to ${current} (${(error as Error).message}); ` +
+        "the editor starts on a fresh profile, the old one is still there\n",
+    );
+  }
 }
 
 function forgetOldThemeExtensions(keep: string): void {
@@ -41,9 +62,7 @@ function forgetOldThemeExtensions(keep: string): void {
     }
   }
 }
-// hm
 export const PALETTE_CACHE = path.join(DATA_DIR, "palette.json");
-// hm
 export const LIVE_THEME_FILE = path.join(DATA_DIR, "live-theme.json");
 
 export const FONT_FAMILY = "JetBrains Mono";
@@ -59,7 +78,6 @@ export function assetPath(name: string): string {
 
 export const FONT_ASSET = FONT_FILE;
 
-// interesting, we actually install the font at a legimate location?
 export function userFontsDir(): string {
   if (process.platform === "darwin") return path.join(os.homedir(), "Library", "Fonts");
   const dataHome =
@@ -132,9 +150,6 @@ function writeIfChanged(file: string, contents: string): boolean {
   return true;
 }
 
-/**
- * sus
- */
 export interface ThemeDocument {
   name?: string;
   type?: string;
@@ -251,22 +266,22 @@ export const SETTINGS: Record<string, unknown> = {
   "workbench.startupEditor": "none",
   "workbench.secondarySideBar.defaultVisibility": "hidden",
   "chat.commandCenter.enabled": false,
-  // wait what
   "workbench.tips.enabled": false,
   "workbench.welcomePage.walkthroughs.openOnInstall": false,
   "window.commandCenter": false,
-  // The default title format ends in ${appName} — "code-server". The folder is
-  // already on the window above this bar, so the file name is the only part
-  // left worth showing. ${dirty} puts a dot in front of unsaved work.
+  // The default title format ends in ${appName} — "Visual Studio Code". The
+  // folder is already on the window above this bar, so the file name is the
+  // only part left worth showing. ${dirty} puts a dot in front of unsaved work.
   "window.title": "${dirty}${activeEditorShort}",
-  // wait why are we applying this?
   "editor.smoothScrolling": false,
   "workbench.list.smoothScrolling": false,
-  // huh?
   "terminal.integrated.smoothScrolling": false,
   "update.mode": "none",
   "telemetry.telemetryLevel": "off",
   "workbench.enableExperiments": false,
+  // code-server took --disable-workspace-trust; serve-web has no such flag, and
+  // a trust prompt over a folder the user just asked for is only in the way
+  "security.workspace.trust.enabled": false,
 };
 
 export const SEEDED_SETTINGS: Record<string, unknown> = {
@@ -314,6 +329,7 @@ export function applySettings(source: string): string {
 }
 
 export function installSettings(): boolean {
+  adoptServerLayout();
   const file = path.join(USER_DIR, "settings.json");
   let source = "";
   try {
@@ -404,6 +420,23 @@ export function foreignBindings(): Binding[] {
 
 export function installKeybindings(): boolean {
   return writeBindings(todeKeybindings() as Binding[], foreignBindings());
+}
+
+/** The bindings the workbench should end up with — the same list that goes into
+ * keybindings.json, minus what an extension cannot say.
+ *
+ * A workbench in a browser keeps its user keybindings in the browser, not in
+ * the server's data dir, so keybindings.json is tode's record of the intent and
+ * the bridge extension is what actually carries it in. Extensions contribute
+ * defaults, so removals ("-command") have nowhere to go and are dropped: a
+ * chord handed to the terminal keeps whatever the workbench binds it to. */
+export function liveBindings(): Binding[] {
+  const theirs = foreignBindings();
+  const mine = todeKeybindings() as Binding[];
+  const winners = [...overrideBindings(), ...claimBindings(), ...quitWinsBindings(theirs)];
+  return [...mine, ...theirs, ...winners].filter(
+    (entry) => !!entry.key && !!entry.command && !entry.command.startsWith("-"),
+  );
 }
 
 function quitWinsBindings(theirs: Binding[]): Binding[] {

--- a/src/runtime/release.ts
+++ b/src/runtime/release.ts
@@ -1,4 +1,3 @@
-
 import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -166,12 +165,15 @@ export async function fetchVerified(
   fs.mkdirSync(path.dirname(tarball), { recursive: true });
   const hash = crypto.createHash("sha256");
   const file = fs.createWriteStream(tarball);
+  // a release table carries the size; a download named by a service may only
+  // announce it in the response, and without either there is no percentage
+  const total = size || Number(response.headers.get("content-length")) || 0;
   let read = 0;
   for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
     hash.update(chunk);
     read += chunk.byteLength;
     if (!file.write(chunk)) await new Promise<void>((resolve) => file.once("drain", () => resolve()));
-    if (size) onProgress?.(read / size);
+    if (total) onProgress?.(read / total);
   }
   await new Promise<void>((resolve, reject) => {
     file.end((error?: Error | null) => (error ? reject(error) : resolve()));

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 
 import { BRIDGE_DIR, STARTUP_OPEN_FILE } from "./bridge";
 import { ipcSocketDir } from "./browserglue";
-import { CSS_FILE, PORT_FILE, STATE_FILE, currentServer, origin } from "./codeserver/server";
-import { CODE_SERVER_VERSION, codeServerRoot, installedCodeServer } from "./codeserver/vendored";
+import { CSS_FILE, PORT_FILE, SERVER_LOG, STATE_FILE, currentServer, origin } from "./codeserver/server";
+import { CLI_DATA_DIR, CLI_DIR, installedVscodeCli, installedVscodeServer } from "./codeserver/vendored";
 import {
   EXTENSIONS_DIR,
   KEYBINDINGS_RECORD,
@@ -22,7 +22,6 @@ import {
   CACHE_DIR,
   DATA_DIR,
   INSTALL_ROOT,
-  LOGS_DIR,
   RUNTIME_DIR,
   STATE_DIR,
   VENDOR_DIR,
@@ -73,10 +72,11 @@ export async function skillText(): Promise<string> {
 
   const server = await currentServer();
   const daemon = server
-    ? `up ${Math.round((Date.now() - server.startedAt) / 60000)}m — code-server pid ${server.pid} on 127.0.0.1:${server.port}, ` +
-    `injector pid ${server.injectorPid}; windows load ${origin(server)} (always the injector, never code-server directly)`
+    ? `up ${Math.round((Date.now() - server.startedAt) / 60000)}m — serve-web pid ${server.pid} on 127.0.0.1:${server.port}, ` +
+    `injector pid ${server.injectorPid}; windows load ${origin(server)} (always the injector, never the server directly)`
     : "not running — the next `tode` starts it";
-  const codeServer = installedCodeServer();
+  const cli = installedVscodeCli();
+  const vscodeServer = installedVscodeServer();
 
   const sockets = listDir(ipcSocketDir()).filter((entry) => entry.endsWith(".sock"));
   const inWindow = process.env.TODE_IPC;
@@ -91,13 +91,13 @@ export async function skillText(): Promise<string> {
 
   return `---
 name: tode
-description: Working knowledge of this machine's tode install (the terminal code editor). Where its code-server profile, extensions, keybindings, themes, terminal shortcut overrides, logs and daemon state live, which files are safe to edit and which are regenerated, and how to reach running windows. Regenerate with \`tode --skill\` — every path is resolved live and the state section reflects the moment it ran.
+description: Working knowledge of this machine's tode install (the terminal code editor). Where its VS Code profile, extensions, keybindings, themes, terminal shortcut overrides, logs and daemon state live, which files are safe to edit and which are regenerated, and how to reach running windows. Regenerate with \`tode --skill\` — every path is resolved live and the state section reflects the moment it ran.
 ---
 
 # tode
 
-tode is a code editor that runs in the terminal: one warm code-server serves
-the VS Code workbench, an injecting proxy sits in front of it, and
+tode is a code editor that runs in the terminal: one warm \`code serve-web\`
+serves the real VS Code workbench, an injecting proxy sits in front of it, and
 terminal-browser draws each window as a terminal pane. Everything below was
 resolved on this machine when \`tode --skill\` ran — env overrides are already
 applied, and the state section is live. Re-run it rather than trusting a copy.
@@ -107,7 +107,8 @@ applied, and the state section is live. Re-run it rather than trusting a copy.
 - install root: ${INSTALL_ROOT} — ${install}
 - shim: ${shim} ${fs.existsSync(shim) ? "(present)" : "(absent — run installs go through node directly)"}
 - terminal-browser pin ${PINNED_VERSION}: ${runtimeSources()}
-- code-server ${CODE_SERVER_VERSION}: ${codeServer ?? `not fetched yet — the first open puts it under ${codeServerRoot()}`}
+- VS Code cli: ${cli ?? `not fetched yet — the first open puts it under ${CLI_DIR}`}
+- VS Code server: ${vscodeServer ?? `not fetched yet — serve-web downloads it under ${path.join(CLI_DATA_DIR, "serve-web")} on the first window`}
 - daemon: ${daemon}
 - open windows: ${sockets.length} socket(s) in ${ipcSocketDir()}${sockets.length ? ` — ${sockets.join(", ")}` : ""}
 - this shell ${inWindow ? `is inside a tode window (TODE_IPC=${inWindow})` : "is not inside a tode window (no TODE_IPC)"}
@@ -120,6 +121,13 @@ There is exactly one profile, under ${VSCODE_DIR}. Flags like --profile and
 --user-data-dir are deliberately swallowed; every window and every extension
 operation uses this one.
 
+A workbench in a browser keeps its user data in the browser, not in the
+server's data dir, so these files are tode's record of the intent and two
+carriers take them the rest of the way: settings ride in on the workbench page
+as configuration defaults (the injector reads settings.json on every load, so a
+reload is enough), and keybindings ride in on the bridge extension. Anything
+set from inside the editor still wins over both, and lives in the browser.
+
 - ${path.join(USER_DIR, "settings.json")} — live settings. tode owns these keys
   and rewrites them on every open (edits to them are lost):
   ${Object.keys(SETTINGS).join(", ")}.
@@ -128,13 +136,14 @@ operation uses this one.
   Every other key is untouched — add or change freely.
 - ${path.join(USER_DIR, "keybindings.json")} — safe to edit. tode replaces only
   the entries it wrote last time (recorded in ${KEYBINDINGS_RECORD}) and
-  carries everything else through.
+  carries everything else through. An extension can only add bindings, so a
+  removal ("-command") is recorded here but never reaches the workbench.
 - ${path.join(USER_DIR, "snippets")} and tasks.json — plain vscode files, never
   touched after an import.
 - ${EXTENSIONS_DIR} — the extensions tree plus its extensions.json registry.
   Manage with \`tode --install-extension <id|vsix>\`, \`--uninstall-extension\`,
-  \`--list-extensions\` (these force the right dirs; a bare code-server call
-  would land in the wrong profile). Two entries are generated by tode itself
+  \`--list-extensions\` (these run the downloaded VS Code server against the
+  right dirs; a bare \`code\` call would look for a desktop install). Two entries are generated by tode itself
   and rewritten on every open, so never hand-edit them: ${path.basename(BRIDGE_DIR)}
   (the IPC bridge) and ${THEME_EXTENSION_ID}-<fingerprint> (the terminal theme).
 - an open window picks extension changes up on its next reload.
@@ -176,18 +185,20 @@ ${STARTUP_OPEN_FILE} is a one-shot marker with the parts of an open the url cann
 
 ## Daemon and processes
 
-- ${STATE_FILE} — pids and ports of code-server and the injector; treat as
+- ${STATE_FILE} — pids and ports of the VS Code server and the injector; treat as
   read-only, \`tode --shutdown\` removes it properly.
 - ${PORT_FILE} — the injector's sticky port, reused while free so saved
   workspaces and the chromium cache stay valid.
-- ${path.join(LOGS_DIR, "code-server.log")} — combined code-server + injector log, append-only.
-- code-server runs with --auth none on 127.0.0.1, user-data ${path.join(VSCODE_DIR, "user-data")},
-  extensions ${EXTENSIONS_DIR}.
+- ${SERVER_LOG} — combined server + injector log, append-only.
+- the workbench is served by \`code serve-web --without-connection-token\` on
+  127.0.0.1, --server-data-dir ${VSCODE_DIR} (so user data ${path.join(VSCODE_DIR, "data")},
+  extensions ${EXTENSIONS_DIR}) and --cli-data-dir ${CLI_DATA_DIR}.
 
 ## Homes on disk
 
-- data ${DATA_DIR} — profile, theme, generated scripts, fetched code-server
-  (${path.join(DATA_DIR, "code-server")}) and terminal-browser trees (${RUNTIME_DIR})
+- data ${DATA_DIR} — profile, theme, generated scripts, the fetched VS Code cli
+  (${CLI_DIR}), the servers it downloads (${CLI_DATA_DIR}) and terminal-browser
+  trees (${RUNTIME_DIR})
 - state ${STATE_DIR} — daemon state, logs, ipc sockets, install receipt (install.json)
 - cache ${CACHE_DIR} — converted app icons and the browser's cache
 - terminal-browser gets its own homes so the user's are untouched:
@@ -200,7 +211,8 @@ ${STARTUP_OPEN_FILE} is a one-shot marker with the parts of an open the url cann
 
 - TODE_IPC — set inside tode windows; the window's socket
 - TODE_INSTALL_ROOT — overrides the install tree
-- TODE_CODE_SERVER — use your own code-server binary
+- TODE_VSCODE_CLI — use your own VS Code \`code\` cli binary
+- TODE_VSCODE_UPDATE_ORIGIN — where the cli is looked up and downloaded from
 - TODE_TERMINAL_BROWSER_BIN — use your own terminal-browser
 - TODE_RELEASE_ORIGIN — where upgrades and runtime downloads come from
 - TODE_BROWSER_DATA/_STATE/_CACHE/_RUN/_APPDATA — move the browser homes

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -5,7 +5,12 @@ const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
-const { createInjector, injectedCss, FONT_ROUTE } = require("../dist/codeserver/inject.js");
+const {
+  createInjector,
+  injectedCss,
+  withWorkbenchDefaults,
+  FONT_ROUTE,
+} = require("../dist/codeserver/inject.js");
 
 const listen = (server) =>
   new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server.address().port)));
@@ -25,7 +30,7 @@ const close = (server) =>
     setTimeout(done, 100).unref();
   });
 
-/** stands in for code-server, and remembers the headers it was handed */
+/** stands in for the VS Code server, and remembers the headers it was handed */
 function fakeUpstream(handler) {
   const seen = [];
   const server = http.createServer((request, response) => {
@@ -40,15 +45,21 @@ function fakeUpstream(handler) {
   return { server, seen };
 }
 
-async function withPair(handler, run) {
+async function withPair(handler, run, settings) {
   const { server: upstream, seen } = fakeUpstream(handler);
   const upstreamPort = await listen(upstream);
-  const cssFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "tode-css-")), "inject.css");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tode-css-"));
+  const cssFile = path.join(dir, "inject.css");
   fs.writeFileSync(cssFile, "html{background:#101010 !important;}");
-  const proxy = createInjector(upstreamPort, cssFile);
+  let settingsFile;
+  if (settings !== undefined) {
+    settingsFile = path.join(dir, "settings.json");
+    fs.writeFileSync(settingsFile, settings);
+  }
+  const proxy = createInjector(upstreamPort, cssFile, undefined, undefined, settingsFile);
   const proxyPort = await listen(proxy);
   try {
-    await run({ proxyPort, upstreamPort, seen, cssFile });
+    await run({ proxyPort, upstreamPort, seen, cssFile, settingsFile });
   } finally {
     await close(proxy);
     await close(upstream);
@@ -116,16 +127,20 @@ test("a document with no head still gets the css", async () => {
   );
 });
 
-test("upstream is told the request came from itself", async () => {
+test("the workbench is left on one origin: the client's own host goes through", async () => {
   await withPair(
     (_request, response) => {
       response.writeHead(200, { "content-type": "text/html" });
       response.end("<html><head></head></html>");
     },
-    async ({ proxyPort, upstreamPort, seen }) => {
+    async ({ proxyPort, seen }) => {
       await get(proxyPort, { accept: "text/html", origin: `http://127.0.0.1:${proxyPort}` });
-      assert.equal(seen[0].headers.host, `127.0.0.1:${upstreamPort}`);
-      assert.equal(seen[0].headers.origin, `http://127.0.0.1:${upstreamPort}`);
+      // the server builds the workbench's remote authority out of the host it
+      // was asked with, and its content security policy then only allows that
+      // one origin — pointing it at the upstream would block every resource
+      // the page fetches
+      assert.equal(seen[0].headers.host, `127.0.0.1:${proxyPort}`);
+      assert.equal(seen[0].headers.origin, `http://127.0.0.1:${proxyPort}`);
     },
   );
 });
@@ -233,7 +248,7 @@ test("the proxy injects css and never a script", async () => {
   );
 });
 
-test("a request waits while code-server is still booting, then goes through", async () => {
+test("a request waits while the VS Code server is still booting, then goes through", async () => {
   const late = http.createServer((_q, r) => {
     r.writeHead(200, { "content-type": "text/html" });
     r.end("<html><head></head><body>up</body></html>");
@@ -251,7 +266,7 @@ test("a request waits while code-server is still booting, then goes through", as
   });
   try {
     const pending = get(proxyPort, { accept: "text/html" });
-    // nothing is listening upstream yet, exactly as when code-server is booting
+    // nothing is listening upstream yet, exactly as when serve-web is booting
     await new Promise((resolve) => setTimeout(resolve, 300));
     await new Promise((resolve) => revived.listen(port, "127.0.0.1", resolve));
     const { status, body } = await pending;
@@ -268,3 +283,53 @@ test("the empty editor stays empty: the watermark is always hidden", () => {
   assert.match(css, /\.editor-group-watermark\{display:none !important;\}/);
 });
 
+
+const workbenchPage = (settings) =>
+  `<html><head><meta id="vscode-workbench-web-configuration" data-settings="${settings
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")}"></head><body></body></html>`;
+
+test("tode's settings reach the workbench as configuration defaults", () => {
+  const html = workbenchPage(JSON.stringify({ folderUri: { path: "/w" } }));
+  const out = withWorkbenchDefaults(html, { "workbench.colorTheme": "Tode" });
+  const settings = JSON.parse(
+    out
+      .match(/data-settings="([^"]*)"/)[1]
+      .replaceAll("&quot;", '"')
+      .replaceAll("&#39;", "'")
+      .replaceAll("&lt;", "<")
+      .replaceAll("&gt;", ">")
+      .replaceAll("&amp;", "&"),
+  );
+  // what the server put there survives
+  assert.deepEqual(settings.folderUri, { path: "/w" });
+  assert.deepEqual(settings.configurationDefaults, { "workbench.colorTheme": "Tode" });
+  // the folder was asked for by name, so it is not put behind a trust prompt
+  assert.equal(settings.enableWorkspaceTrust, false);
+});
+
+test("a page without the workbench configuration is left alone", () => {
+  const plain = "<html><head></head></html>";
+  assert.equal(withWorkbenchDefaults(plain, { a: 1 }), plain);
+  const broken = workbenchPage("{not json");
+  assert.equal(withWorkbenchDefaults(broken, { a: 1 }), broken);
+});
+
+test("the settings file is read on every load, so an edit lands on refresh", async () => {
+  await withPair(
+    (_request, response) => {
+      response.writeHead(200, { "content-type": "text/html" });
+      response.end(workbenchPage("{}"));
+    },
+    async ({ proxyPort, settingsFile }) => {
+      const first = await get(proxyPort, { accept: "text/html" });
+      assert.match(first.body, /&quot;workbench.colorTheme&quot;:&quot;Tode&quot;/);
+      fs.writeFileSync(settingsFile, '{ "editor.fontSize": 17 }');
+      const second = await get(proxyPort, { accept: "text/html" });
+      assert.match(second.body, /&quot;editor.fontSize&quot;:17/);
+      // and the css is still there alongside it
+      assert.match(second.body, /<style id="tode-injected">/);
+    },
+    '{\n  // tode owns this one\n  "workbench.colorTheme": "Tode",\n}',
+  );
+});

--- a/test/livesync.test.js
+++ b/test/livesync.test.js
@@ -30,7 +30,7 @@ test("a full colours file round-trips through withFallbacks", () => {
 });
 
 /** loads the generated bridge extension in a sandbox with a fake vscode, so
- * the live-settings watch is exercised the same way code-server would run it,
+ * the live-settings watch is exercised the same way serve-web would run it,
  * not just checked for valid syntax. os.homedir() is pointed at a scratch
  * directory too, since activate() also stands up the real ipc socket and this
  * must not touch the actual home directory while doing it. */

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -217,17 +217,18 @@ test("chords canonicalise across spellings, and sequences count as their opener"
   assert.equal(canonicalChord("cmd+k cmd+s"), "cmd+k");
 });
 
-test("the vendored keymap was generated from the pinned code-server", () => {
-  // regenerate with scripts/generate-keymaps.js when the pin moves
-  const { CODE_SERVER_VERSION } = require("../dist/codeserver/vendored.js");
+test("the vendored keymap says which VS Code it was dumped from", () => {
+  // regenerate with scripts/generate-keymaps.js; the served VS Code moves with
+  // stable, so the record is provenance rather than a pin to check against
   for (const platform of ["mac", "linux"]) {
     const file = path.join(__dirname, "..", "assets", "keymaps", `vscode-${platform}.json`);
     const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
-    assert.equal(
-      parsed.codeServer,
-      CODE_SERVER_VERSION,
-      `assets/keymaps/vscode-${platform}.json is from code-server ${parsed.codeServer}, the pin is ${CODE_SERVER_VERSION}`,
+    assert.match(
+      parsed.vscode ?? "",
+      /^\d+\.\d+\.\d+$/,
+      `assets/keymaps/vscode-${platform}.json does not name the VS Code it came from`,
     );
+    assert.equal(parsed.platform, platform);
     assert.ok(parsed.bindings.length > 500, "a real keymap has hundreds of bindings");
   }
 });
@@ -411,6 +412,49 @@ test("derived editor decisions write keybindings through the command on the deci
     });
     const bindings = store.fallbackBindings();
     assert.deepEqual(bindings, [{ key: "ctrl+alt+f", command: "actions.find", when: "!terminalFocus" }]);
+  } finally {
+    process.env.XDG_DATA_HOME = prev.XDG_DATA_HOME;
+    process.env.XDG_STATE_HOME = prev.XDG_STATE_HOME;
+    fs.rmSync(home, { recursive: true, force: true });
+    for (const key of Object.keys(require.cache)) delete require.cache[key];
+  }
+});
+
+test("the bridge extension carries the bindings the browser cannot read off disk", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tode-live-"));
+  const prev = { XDG_DATA_HOME: process.env.XDG_DATA_HOME, XDG_STATE_HOME: process.env.XDG_STATE_HOME };
+  process.env.XDG_DATA_HOME = path.join(home, "share");
+  process.env.XDG_STATE_HOME = path.join(home, "state");
+  try {
+    const store = freshRequire("../dist/shortcuts/store.js");
+    store.saveDecisions({
+      version: 1,
+      terminal: "ghostty",
+      choices: {
+        "cmd+shift+z": { choice: "editor", key: "ctrl+shift+z", command: "redo" },
+        "claim:ctrl+k": { choice: "terminal", action: "workbench.action.terminal.clear" },
+      },
+    });
+    const profile = require("../dist/profile.js");
+    const { installBridge, BRIDGE_DIR } = require("../dist/bridge.js");
+    // a binding of the user's own, which tode keeps
+    fs.mkdirSync(profile.USER_DIR, { recursive: true });
+    fs.writeFileSync(
+      path.join(profile.USER_DIR, "keybindings.json"),
+      JSON.stringify([{ key: "alt+g", command: "acme.go" }]),
+    );
+    installBridge(["tode"]);
+    const manifest = JSON.parse(fs.readFileSync(path.join(BRIDGE_DIR, "package.json"), "utf8"));
+    const bindings = manifest.contributes.keybindings;
+    const has = (key, command) => bindings.some((b) => b.key === key && b.command === command);
+    assert.ok(has(store.QUIT_CHORD, store.QUIT_COMMAND), "quit still comes with the bridge");
+    assert.ok(has("ctrl+shift+z", "redo"), "a decision reaches the workbench");
+    assert.ok(has("alt+g", "acme.go"), "and so does the user's own binding");
+    // an extension contributes defaults, so it has no way to say "unbind this"
+    assert.ok(
+      !bindings.some((b) => b.command.startsWith("-")),
+      "removals cannot be contributed, so they are left out",
+    );
   } finally {
     process.env.XDG_DATA_HOME = prev.XDG_DATA_HOME;
     process.env.XDG_STATE_HOME = prev.XDG_STATE_HOME;

--- a/test/vscode.test.js
+++ b/test/vscode.test.js
@@ -1,0 +1,219 @@
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+/* the modules below resolve their homes at load time, so the scratch ones have
+   to be in the environment before the first require */
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), "tode-vscode-"));
+process.env.XDG_DATA_HOME = path.join(HOME, "share");
+process.env.XDG_STATE_HOME = path.join(HOME, "state");
+delete process.env.TODE_VSCODE_CLI;
+
+const {
+  CLI_DATA_DIR,
+  CLI_DIR,
+  ensureVscodeCli,
+  installedVscodeCli,
+  installedVscodeServer,
+  latestCli,
+} = require("../dist/codeserver/vendored.js");
+const { serveWebArgs } = require("../dist/codeserver/server.js");
+
+/** an update service that answers exactly like update.code.visualstudio.com */
+async function updateService(answer, asset) {
+  const server = http.createServer((request, response) => {
+    if (asset && request.url === "/asset") {
+      response.writeHead(200, { "content-type": "application/octet-stream" });
+      response.end(asset);
+      return;
+    }
+    if (!answer) {
+      response.writeHead(404);
+      response.end("nope");
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(answer));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  return {
+    origin,
+    // fetch keeps its sockets alive, so they are dropped rather than waited for
+    close: () =>
+      new Promise((resolve) => {
+        server.closeAllConnections();
+        server.close(resolve);
+      }),
+  };
+}
+
+/** the shape the cli ships in: one gzipped tar holding the `code` binary */
+function cliTarball(body) {
+  const scratch = fs.mkdtempSync(path.join(HOME, "pack-"));
+  fs.writeFileSync(path.join(scratch, "code"), body);
+  const tarball = path.join(scratch, "cli.tar.gz");
+  execFileSync("tar", ["-czf", tarball, "-C", scratch, "code"]);
+  return fs.readFileSync(tarball);
+}
+
+function withOrigin(origin, run) {
+  const previous = process.env.TODE_VSCODE_UPDATE_ORIGIN;
+  process.env.TODE_VSCODE_UPDATE_ORIGIN = origin;
+  return run().finally(() => {
+    if (previous === undefined) delete process.env.TODE_VSCODE_UPDATE_ORIGIN;
+    else process.env.TODE_VSCODE_UPDATE_ORIGIN = previous;
+  });
+}
+
+test("the workbench is served by code serve-web, on loopback, out of tode's own dirs", () => {
+  const args = serveWebArgs(41234);
+  assert.equal(args[0], "serve-web", "the real cli's own web server, not a fork");
+  const value = (flag) => args[args.indexOf(flag) + 1];
+  assert.equal(value("--host"), "127.0.0.1", "never reachable off this machine");
+  assert.equal(value("--port"), "41234");
+  assert.ok(args.includes("--without-connection-token"), "the injector is the only client");
+  assert.ok(args.includes("--accept-server-license-terms"), "otherwise it stops and asks");
+  assert.ok(args.includes("--disable-telemetry"));
+  // the server derives its user data and extensions from --server-data-dir; a
+  // --user-data-dir would be ignored, so the profile has to live under this one
+  assert.equal(value("--server-data-dir"), path.join(process.env.XDG_DATA_HOME, "tode", "vscode"));
+  assert.equal(value("--cli-data-dir"), CLI_DATA_DIR, "servers land in tode's tree, not ~/.vscode-cli");
+  const { USER_DIR, EXTENSIONS_DIR } = require("../dist/profile.js");
+  assert.equal(USER_DIR, path.join(value("--server-data-dir"), "data", "User"));
+  assert.equal(EXTENSIONS_DIR, path.join(value("--server-data-dir"), "extensions"));
+});
+
+test("the cli that gets fetched is the one the update service names for this machine", async () => {
+  const service = await updateService({
+    url: "unused",
+    version: "cafe1234",
+    productVersion: "1.105.2",
+    sha256hash: "deadbeef",
+    size: 12,
+  });
+  try {
+    const release = await withOrigin(service.origin, () => latestCli());
+    assert.equal(release.version, "1.105.2");
+    assert.equal(release.commit, "cafe1234", "the version field of the document is the commit");
+    assert.equal(release.sha256, "deadbeef");
+  } finally {
+    await service.close();
+  }
+});
+
+test("an update service with nothing to offer is reported, not half-installed", async () => {
+  const service = await updateService({ version: "cafe1234" });
+  try {
+    await assert.rejects(
+      withOrigin(service.origin, () => latestCli()),
+      /did not name a cli-.* build to download/,
+    );
+  } finally {
+    await service.close();
+  }
+  const gone = await updateService(null);
+  try {
+    await assert.rejects(
+      withOrigin(gone.origin, () => latestCli()),
+      /did not answer \(404/,
+    );
+  } finally {
+    await gone.close();
+  }
+});
+
+test("the downloaded cli is checked against the digest the service published", async () => {
+  const asset = cliTarball("#!/bin/sh\necho 1.105.2\n");
+  const sha256 = crypto.createHash("sha256").update(asset).digest("hex");
+  const service = await updateService(
+    { url: null, version: "cafe1234", productVersion: "1.105.2", sha256hash: sha256, size: asset.length },
+    asset,
+  );
+  try {
+    // a tampered download is refused and nothing is left behind to be run
+    const bad = await updateService(
+      {
+        url: `${service.origin}/asset`,
+        version: "cafe1234",
+        productVersion: "9.9.9",
+        sha256hash: crypto.createHash("sha256").update("something else").digest("hex"),
+        size: asset.length,
+      },
+      asset,
+    );
+    await assert.rejects(withOrigin(bad.origin, () => ensureVscodeCli()), /download corrupted/);
+    await bad.close();
+    assert.equal(installedVscodeCli(), null, "a corrupted download installs nothing");
+
+    const good = await updateService(
+      {
+        url: `${service.origin}/asset`,
+        version: "cafe1234",
+        productVersion: "1.105.2",
+        sha256hash: sha256,
+        size: asset.length,
+      },
+      asset,
+    );
+    const bin = await withOrigin(good.origin, () => ensureVscodeCli());
+    await good.close();
+    assert.equal(bin, path.join(CLI_DIR, "1.105.2", "code"));
+    assert.ok(fs.statSync(bin).mode & 0o111, "the cli is executable");
+    assert.equal(installedVscodeCli(), bin, "and is found again without another download");
+  } finally {
+    await service.close();
+    fs.rmSync(CLI_DIR, { recursive: true, force: true });
+  }
+});
+
+test("a version that would escape the cli directory is refused, not turned into a path", async () => {
+  for (const productVersion of ["../../../../tmp/pwned", "1.105.2/../..", ".", "..", "-rf", "/etc"]) {
+    const service = await updateService({
+      url: "http://127.0.0.1:1/asset",
+      version: "cafe1234",
+      productVersion,
+      sha256hash: "deadbeef",
+      size: 1,
+    });
+    try {
+      await assert.rejects(
+        withOrigin(service.origin, () => latestCli()),
+        /will not use as a path/,
+        `${productVersion} should never become a directory name`,
+      );
+    } finally {
+      await service.close();
+    }
+  }
+  assert.equal(installedVscodeCli(), null, "and nothing was written for any of them");
+});
+
+test("extension commands find the server serve-web downloaded, never a half-written one", () => {
+  const cache = path.join(CLI_DATA_DIR, "serve-web");
+  fs.rmSync(cache, { recursive: true, force: true });
+  assert.equal(installedVscodeServer(), null, "nothing to find before the first window");
+
+  const landed = path.join(cache, "aaaa1111", "bin", "code-server");
+  fs.mkdirSync(path.dirname(landed), { recursive: true });
+  fs.writeFileSync(landed, "#!/bin/sh\n");
+  // the cli stages a download beside the finished ones and keeps an lru index
+  const staging = path.join(cache, "bbbb2222.staging", "bin", "code-server");
+  fs.mkdirSync(path.dirname(staging), { recursive: true });
+  fs.writeFileSync(staging, "#!/bin/sh\n");
+  fs.writeFileSync(path.join(cache, "lru.json"), "{}");
+
+  assert.equal(installedVscodeServer(), landed);
+
+  const newer = path.join(cache, "cccc3333", "bin", "code-server");
+  fs.mkdirSync(path.dirname(newer), { recursive: true });
+  fs.writeFileSync(newer, "#!/bin/sh\n");
+  const later = Date.now() / 1000 + 60;
+  fs.utimesSync(newer, later, later);
+  assert.equal(installedVscodeServer(), newer, "the newest server wins after an update");
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -67,14 +67,15 @@ export default function Home() {
             <p className="mt-3 max-w-[560px] text-[13px] leading-[1.75] text-muted">
               terminal-code combines{" "}
               <a
-                href="https://github.com/coder/code-server"
+                href="https://github.com/microsoft/vscode"
                 target="_blank"
                 rel="noreferrer"
                 className="text-text2 underline decoration-border underline-offset-[3px] transition-colors hover:text-ok hover:decoration-ok/50"
               >
-                code-server
+                VS Code
               </a>{" "}
-              (VS Code in the browser) and{" "}
+              (served to the browser by its own{" "}
+              <span className="font-mono">code serve-web</span>) and{" "}
               <a
                 href="https://github.com/zenbu-labs/terminal-browser"
                 target="_blank"


### PR DESCRIPTION
I threw Copilot + Opus 5 at this feature and looks like it works pretty well, here's some AI generated details:

tode now serves its workbench with `code serve-web`, the web server built into the official VS Code CLI. The editor in the terminal is the build Microsoft ships, and new releases arrive the day they land, with no version to pin.

This is your call entirely. Take it, rewrite it, or keep the idea and drop the code.

<img width="3260" height="2102" alt="image" src="https://github.com/user-attachments/assets/de63bdf8-fc7e-4c4e-9af4-75e8b4280dfd" />

## Getting the editor

`src/codeserver/vendored.ts` fetches the `code` CLI from the update service VS Code itself updates from (`/api/update/{cli-target}/stable/latest`) and checks it against the sha256 that document publishes. `TODE_CODE_SERVER` becomes `TODE_VSCODE_CLI`, and `TODE_VSCODE_UPDATE_ORIGIN` moves the lookup.

`src/codeserver/server.ts` runs `code serve-web` on loopback with `--server-data-dir`, `--cli-data-dir`, `--accept-server-license-terms`, `--disable-telemetry` and `--without-connection-token`.

The server only downloads once a page is requested, so `ensureVscodeServer()` provokes that and waits, and a first run says what it is waiting on.

## Profile

`--server-data-dir <dir>` fixes user data at `<dir>/data`, so `USER_DIR` moves to `data/User` and `adoptServerLayout()` renames an existing `user-data/` across once.

A workbench in a browser keeps its user data in the browser, not in the server's data dir. Files on disk are tode's record of the intent. Two carriers take them the rest of the way.

Settings ride in on the document. The injector already rewrote the workbench HTML for CSS, so it now also merges `settings.json` into the `vscode-workbench-web-configuration` meta as `configurationDefaults`. That is what "tode owns these keys, edits are lost" already meant, and anything set inside the editor still wins.

Keybindings ride in on the bridge extension (`liveBindings()`). Extensions can only contribute defaults, so removals (`-command`) are recorded but never reach the workbench.

`--disable-workspace-trust` has no `serve-web` equivalent, so `enableWorkspaceTrust: false` goes on the same meta and `security.workspace.trust.enabled` on settings.

## One origin

The workbench builds its resource and websocket URLs from the `Host` it was asked with. The injector used to rewrite `Host`, `Origin` and `Referer`, which left the page fetching cross-origin against its own CSP. It now carries the client's host straight through.

## Extensions

`code --install-extension` drives a desktop install, and there is no desktop here. Extension commands run the server binary that `serve-web` downloaded, against tode's dirs. That makes them async, since the binary may not exist yet.

## Hardening

The version the update service names becomes a directory under `vscode-cli/`, then the path of a binary tode executes. It is rejected unless it is a plain name, so a redirected or compromised service cannot choose where tode writes or what it runs.

```ts
function safeVersion(version: string): string {
  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(version) || version.includes("..")) {
    throw new Error(`the VS Code update service named a version tode will not use as a path: ${version}`);
  }
  return version;
}
```

## Also

`scripts/generate-keymaps.js` dumps from `serve-web` and records the real `vscode.version` it saw. `README.md`, `web/app/page.tsx` and `src/skill.ts` updated. New `test/vscode.test.js`, plus injector and bridge coverage.

## Verification

I ran this on Linux against the live service. Re-fetching the CLI and hashing it against the binary the running server executed:

```
fresh from update.code.visualstudio.com : b139bff05accd39619c1ce5379e4367490582a718bfc467216138d9c5604af68
binary the running tode is executing    : b139bff05accd39619c1ce5379e4367490582a718bfc467216138d9c5604af68
```

The server reports itself as stock stable, on the real Marketplace:

```
nameLong          : "Visual Studio Code"
quality           : "stable"
version           : "1.134.0"
commit            : "110a328ea54b42367b803ec53ee0bf52ef26b419"
extensionsGallery : marketplace.visualstudio.com/_apis/pub...
```

tode's own layer survives the swap. `tode-injected`, `__tode/font.ttf`, `configurationDefaults` and `Terminal Code` each appear once in the served HTML.

127 tests pass, typecheck clean.

## One decision worth your judgement

`serve-web` runs with `--without-connection-token`. It binds `127.0.0.1`, so nothing on the network reaches it, but another local user on a shared machine could. That suits a single-user desktop tool and matches how the injector already binds. If you would rather have a token threaded through the injector, say so and I will add it.
