### PR TITLE
feat: add doctor diagnostics and repair command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ terminal-code combines [terminal-browser](https://github.com/zenbu-labs/terminal
 
 
 
+### Doctor
+
+Use `tode doctor --json` for a read-only, machine-readable diagnosis. It writes exactly one JSON document to stdout; progress and diagnostics stay on stderr.
+
+Use `tode doctor --json --fix` to repair terminal-code-managed state. The repair pass may download checksum-verified pinned runtimes, update terminal-code-owned profile/shortcut files, and start the owned localhost code-server/injector daemon. It never guesses an unresolved shortcut conflict: those remain unchanged, are reported as `needs_input`, and return exit code `2`.
+
+Exit codes are `0` for healthy or warning-only results, `1` for a failed check/repair or remaining error, `2` for required user input, and `64` for invalid doctor options. A second `--fix` run is intended to be idempotent.
+
 ### Shortcuts
 
 Your terminal and terminal-code will likely conflict on important shortcuts, meaning sometimes terminal-code will never even receive your key press. To resolve

--- a/docs/plans/2026-08-20-tode-doctor-json.md
+++ b/docs/plans/2026-08-20-tode-doctor-json.md
@@ -1,0 +1,724 @@
+# `tode doctor --json` Implementation Plan
+
+> **For the implementer:** Execute this plan task-by-task against the approved design spec. Keep each task isolated, run its validation before moving on, and do not create commits unless the user explicitly authorizes commits.
+
+**Goal:** Add `tode doctor [--json] [--fix]` with deterministic diagnostics, verified repairs, stable JSON output, safe shortcut handling, and owned daemon lifecycle repair.
+
+**Architecture:** Add a dependency-injected check/repair plan engine under `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/`. Checks are read-only; repairs are explicit, ordered, idempotent actions. The CLI runs checks, optionally repairs with `--fix`, runs checks again, and renders one shared report model as text or JSON.
+
+**Tech Stack:** TypeScript with Node16 modules, Node built-in `node:test`, existing `fs`, `child_process`, `net`, and `fetch` abstractions. No new dependency is required.
+
+**Design source:** `/Users/pisitkoolplukpol/Work/terminal-code-doctor/docs/superpowers/specs/2026-08-20-tode-doctor-json-design.md`
+
+---
+
+## Implementation constraints
+
+- Canonical syntax is `tode doctor [--json] [--fix]`; preserve all existing path-opening and `--<command>` behavior for other arguments.
+- `doctor` without `--fix` must not write, download, start, stop, or mutate anything.
+- `--fix` may repair only terminal-code-managed state, verified runtime artifacts, supported terminal configuration, and owned code-server/injector processes.
+- Never invent a shortcut decision. Apply saved decisions and shared auto-apply only; unresolved conflicts return `needs_input` and remain unchanged.
+- Never signal an unverified PID. A live PID alone is insufficient ownership evidence.
+- Keep JSON stdout uncontaminated. Progress and diagnostics belong on stderr.
+- Do not add dependencies or alter `package-lock.json`.
+- Use disposable fixtures and dependency injection for network, filesystem, terminal, clock, and process behavior. Do not touch the user's real home or active daemon in tests.
+- Validation is targeted first because host memory is constrained; run the full repository test command only after focused tests pass.
+
+## Task 1: Add report model and status aggregation
+
+**Objective:** Define the stable report/action/check types and pure summary/exit-code aggregation before any I/O is introduced.
+
+**Files:**
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/model.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-model.test.js`
+
+**Step 1: Write failing tests**
+
+Test that:
+
+- `ok`, `warning`, `error`, `needs_input`, and `skipped` checks serialize as explicit strings;
+- summary counters match the input checks/actions;
+- error exit code `1` takes precedence over `needs_input` exit code `2`;
+- a report with only `needs_input` returns `2`;
+- a healthy report returns `0`.
+
+**Step 2: Run the focused test**
+
+Run:
+
+```bash
+npm run -s build && node --test test/doctor-model.test.js
+```
+
+Expected: FAIL because `/Users/pisitkoolplukpol/Work/terminal-code-doctor/dist/doctor/model.js` does not exist.
+
+**Step 3: Implement the smallest model**
+
+Export the string unions and interfaces from the approved spec. Use a pure function with a shape equivalent to:
+
+```ts
+export function summarize(
+  checks: DoctorCheck[],
+  actions: DoctorAction[],
+): DoctorSummary {
+  const errors = checks.filter((check) => check.status === "error").length;
+  const failed = actions.filter((action) => action.status === "failed").length;
+  const needsInput = checks.filter((check) => check.status === "needs_input").length;
+  const exitCode = errors > 0 || failed > 0 ? 1 : needsInput > 0 ? 2 : 0;
+  return { /* deterministic counters and status */ };
+}
+```
+
+Do not read the filesystem or process environment from this module.
+
+**Step 4: Run the focused test again**
+
+Expected: PASS.
+
+## Task 2: Add pure doctor option parsing
+
+**Objective:** Parse only doctor arguments without changing the existing command dispatcher yet.
+
+**Files:**
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/command.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-command.test.js`
+
+**Step 1: Write failing tests**
+
+Cover:
+
+- `[]` -> `{ json: false, fix: false }`;
+- `['--json']`, `['--fix']`, and both orders;
+- unknown flags and positional arguments return a typed usage error;
+- parser does not mutate its input array;
+- usage errors map to exit code `64` at the command boundary, not by calling `process.exit` inside the parser.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-command.test.js
+```
+
+Expected: FAIL because the parser module is absent.
+
+**Step 3: Implement the parser**
+
+Use a pure signature such as:
+
+```ts
+export interface DoctorOptions { json: boolean; fix: boolean }
+export type DoctorArgs =
+  | { kind: "ok"; options: DoctorOptions }
+  | { kind: "usage-error"; message: string };
+
+export function parseDoctorArgs(args: readonly string[]): DoctorArgs;
+```
+
+**Step 4: Run the focused test**
+
+Expected: PASS.
+
+## Task 3: Create dependency-injected doctor context
+
+**Objective:** Give checks a read-only view of machine and installation facts without importing mutation-heavy launch paths directly.
+
+**Files:**
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/context.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-context.test.js`
+
+**Step 1: Write failing tests**
+
+Use temporary XDG directories and injected fakes to verify that context collection exposes:
+
+- platform and architecture/target triple;
+- TTY booleans;
+- managed data/state/cache directories;
+- pinned terminal-browser version;
+- code-server version and configured override;
+- no filesystem creation during collection.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-context.test.js
+```
+
+Expected: FAIL because context does not exist.
+
+**Step 3: Implement context interfaces**
+
+Keep environment access behind interfaces so tests do not patch globals. Reuse `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/runtime/paths.ts`, `targetTriple()`, `PINNED_VERSION`, and the existing code-server constants for values, but do not call `ensureCodeServer`, `resolveRuntime`, or `ensureServer` while collecting facts.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, including an assertion that the fixture directory remains unchanged.
+
+## Task 4: Add environment, terminal, and managed-path checks
+
+**Objective:** Report basic capability and managed-state findings using the read-only context.
+
+**Files:**
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/checks.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-checks.test.js`
+
+**Step 1: Write failing tests**
+
+Cover:
+
+- supported/unsupported platform values;
+- Ghostty, Kitty, and unknown provider detection through injected environment;
+- non-TTY behavior does not run an interactive terminal query;
+- missing managed directories produce fixable checks without creating them;
+- unreadable state/config produces an error or warning with a redacted detail, not file contents.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-checks.test.js
+```
+
+Expected: FAIL because check registry functions are absent.
+
+**Step 3: Implement read-only checks**
+
+Add a deterministic registry in the order specified by the design. Terminal palette probing may reuse `queryTerminal()` from `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/terminal/osc.ts` only when a TTY is available and must retain its bounded timeout. Do not call `readPalette()` because it writes the palette cache.
+
+**Step 4: Run the focused test**
+
+Expected: PASS with no fixture mutation.
+
+## Task 5: Add pure runtime and code-server inspection
+
+**Objective:** Distinguish healthy, missing, overridden, and corrupt runtime states without invoking download paths.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/runtime/release.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/codeserver/vendored.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-runtime.test.js`
+
+**Step 1: Write failing tests**
+
+Use temporary roots to cover:
+
+- valid vendored/pinned runtime;
+- missing `VERSION`, CLI entry, or Electron entry;
+- `TODE_TERMINAL_BROWSER_BIN` override present/missing;
+- code-server override and pinned binary present/missing;
+- inspection does not call `fetch`, `tar`, `cp`, or write a launcher.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-runtime.test.js
+```
+
+Expected: FAIL because read-only inspection functions are absent.
+
+**Step 3: Implement inspection seams**
+
+Add exported pure/read-only functions such as `inspectRuntime(version, roots)` and `inspectCodeServer(version, roots)`. Refactor existing `usable()`/`binAt()` logic so inspection and repair share the same validity definition. Keep `resolveRuntime()` and `ensureCodeServer()` behavior unchanged until the repair tasks.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, including no-network assertions.
+
+## Task 6: Add profile/generated-state inspection
+
+**Objective:** Report missing or stale terminal-code-owned artifacts without rewriting user-owned settings.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/profile.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/bridge.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-profile.test.js`
+
+**Step 1: Write failing tests**
+
+In an isolated XDG data home, verify findings for:
+
+- missing font, CSS, live theme, bridge manifest/source, settings, keybindings record, and theme registration;
+- existing user settings not flagged as corrupt merely because they contain user-owned keys;
+- generated artifacts are classified as repairable;
+- check-only mode performs no writes.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-profile.test.js
+```
+
+Expected: FAIL because profile inspection is absent.
+
+**Step 3: Implement ownership-aware inspection**
+
+Expose a read-only inventory of paths and owned entries. Reuse `managedSettings()`, `KEYBINDINGS_RECORD`, `BRIDGE_DIR`, and existing profile constants. Do not call `installSettings`, `installKeybindings`, `installBridge`, `ensureFont`, or theme writers from checks.
+
+**Step 4: Run the focused test**
+
+Expected: PASS.
+
+## Task 7: Add shortcut diagnostics and unresolved-decision classification
+
+**Objective:** Report provider readiness, saved decisions, shared conflicts, and unresolved conflicts without opening the shortcut UI.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/shortcuts/provider.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/shortcuts/wizard.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-shortcuts.test.js`
+
+**Step 1: Write failing tests**
+
+Inject fake providers and verify:
+
+- unsupported provider is reported without an erroring shell command;
+- provider not ready is reported with its remediation string;
+- saved decisions and shared conflicts are classified as repairable;
+- unresolved rows are `needs_input` and have no repair permission;
+- a provider scan failure is captured as a check error without writing config.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-shortcuts.test.js
+```
+
+Expected: FAIL because the diagnostic adapter is absent.
+
+**Step 3: Implement a read-only shortcut snapshot**
+
+Add a narrow adapter around `providerFor()`, `provider.scan()`, `loadDecisions()`, and existing shared-conflict logic. Keep `applyDecisions()` private or expose only a repair-safe wrapper later. Do not invoke `runManager()` or `shortcutsCommand()` from doctor.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, including no calls to provider mutation methods.
+
+## Task 8: Add daemon inspection and ownership seams
+
+**Objective:** Safely distinguish a healthy daemon, stale state, missing daemon, and an unattributed process/port.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/codeserver/server.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/process.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-daemon.test.js`
+
+**Step 1: Write failing tests**
+
+Use injected process and TCP probes to cover:
+
+- valid state with both owned PIDs and responsive localhost ports;
+- missing state;
+- dead PIDs with stale state;
+- live but unverified PID, which must be blocked;
+- occupied port that is not attributable to terminal-code;
+- no signal is sent during check-only mode.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-daemon.test.js
+```
+
+Expected: FAIL because ownership-aware inspection is absent.
+
+**Step 3: Implement safe inspection**
+
+Refactor the existing private state reader into a read-only snapshot function. Add an injected process identity probe that verifies command/executable identity before any future signal. Reuse `currentServer()` for endpoint semantics where safe, but do not make `currentServer()` kill or clean anything.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, especially the refusal case for an unverified PID.
+
+## Task 9: Add orchestration and report rendering
+
+**Objective:** Run the check registry deterministically, aggregate status, and render the same report as text or JSON.
+
+**Files:**
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/orchestrator.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/report.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-report.test.js`
+
+**Step 1: Write failing tests**
+
+Verify:
+
+- checks run in stable registry order;
+- exceptions become report entries rather than aborting unrelated checks;
+- JSON output parses as exactly one document;
+- stdout contains no progress text;
+- text and JSON renderers receive equivalent report objects;
+- summary counters and exit code agree with final checks/actions.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-report.test.js
+```
+
+Expected: FAIL because the orchestrator and reporters are absent.
+
+**Step 3: Implement check-only orchestration**
+
+Use an interface similar to:
+
+```ts
+export interface DoctorRunner {
+  run(options: DoctorOptions): Promise<DoctorReport>;
+}
+```
+
+For this task, `fix` must be rejected or ignored only at the internal repair boundary; the final CLI behavior is wired in Task 10. Serialize with `JSON.stringify(report, null, 2) + "\n"` and keep all progress on an injected stderr writer.
+
+**Step 4: Run the focused test**
+
+Expected: PASS.
+
+## Task 10: Wire `tode doctor` into the CLI
+
+**Objective:** Route the canonical command before the existing path parser without regressing other commands.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/main.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-command.test.js`
+
+**Step 1: Extend failing tests**
+
+Add subprocess/entrypoint coverage for:
+
+- `dist/main.js doctor --json`;
+- `dist/main.js doctor --fix --json`;
+- `--json` before/after `--fix`;
+- existing `--help`, path opening, `--skill`, and `--shutdown` routes still dispatch as before;
+- invalid doctor flags return `64` and a JSON usage report only when `--json` was selected.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-command.test.js
+```
+
+Expected: FAIL because `main()` still treats `doctor` as a path.
+
+**Step 3: Implement the route and help text**
+
+Add a `doctor` branch before `openCommand(args)`. Do not call `process.exit` from the doctor implementation; return its code to the existing promise chain. Add the canonical forms and side-effect warning to `HELP` near the other commands.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, with all pre-existing command routes unchanged.
+
+## Task 11: Add managed-state and verified runtime repairs
+
+**Objective:** Repair missing managed directories, terminal-browser runtime, and code-server using existing verified provisioning paths.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/repairs.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/runtime/release.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/codeserver/vendored.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-repairs-runtime.test.js`
+
+**Step 1: Write failing tests**
+
+Use injected fake download/unpack functions to verify:
+
+- missing directories are created only under managed roots;
+- valid runtime is unchanged;
+- missing runtime invokes verified download exactly once;
+- checksum failure removes the temporary archive and reports `failed`;
+- code-server uses its pinned build and does not replace a valid binary.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-repairs-runtime.test.js
+```
+
+Expected: FAIL because repair actions are absent.
+
+**Step 3: Implement actions**
+
+Define repair actions with stable IDs, dependencies, and outcomes. Call existing `resolveRuntime()`/`ensureCodeServer()` only from repair code, passing stderr progress callbacks. Keep check-only execution on the read-only inspection path.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, including the no-partial-artifact assertion.
+
+## Task 12: Add profile and generated-artifact repairs
+
+**Objective:** Regenerate terminal-code-owned profile artifacts while preserving user-authored state.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/repairs.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/profile.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/bridge.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-repairs-profile.test.js`
+
+**Step 1: Write failing tests**
+
+Verify that repair:
+
+- creates the missing generated profile files;
+- preserves unknown/user-owned settings and keybindings;
+- uses write-if-changed behavior on a second run;
+- records each changed/unchanged artifact as an action;
+- uses atomic writes for new JSON output.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-repairs-profile.test.js
+```
+
+Expected: FAIL because profile repair actions are absent.
+
+**Step 3: Implement profile repair**
+
+Compose existing `ensureFont`, `installTheme`, `installCss`, `setLiveTheme`, `installSettings`, `installKeybindings`, `installBridge`, and theme registration behind explicit repair actions. Read the palette through a repair-safe path; do not make the check pass call these functions.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, including byte-for-byte preservation of user-owned entries.
+
+## Task 13: Add shortcut repair with `needs_input`
+
+**Objective:** Apply saved/shared decisions and leave undecided conflicts untouched.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/repairs.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/shortcuts/wizard.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/shortcuts/backends/ghostty.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/shortcuts/backends/kitty.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-repairs-shortcuts.test.js`
+
+**Step 1: Write failing tests**
+
+Using the existing sandbox patterns in `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/shortcuts-loop.test.js`, verify:
+
+- saved decisions apply through the provider;
+- shared conflicts auto-apply;
+- undecided conflicts produce a blocked action and final exit code `2`;
+- undecided config bytes do not change;
+- provider reload hints are recorded;
+- an unsupported provider does not receive a config write.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-repairs-shortcuts.test.js
+```
+
+Expected: FAIL because the doctor repair adapter is absent.
+
+**Step 3: Implement the repair adapter**
+
+Reuse the provider decision application path, but expose a non-interactive function that accepts only already-recorded decisions. Never call `startManager`, `runManager`, or a browser page from doctor. Capture before/after fingerprints of managed shortcut files for action details.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, with unresolved decisions returning `needs_input` and no guessed ownership.
+
+## Task 14: Add safe daemon lifecycle repair
+
+**Objective:** Clean verified stale state and start/verify owned code-server/injector processes without killing unrelated processes or opening a terminal window.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/repairs.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/codeserver/server.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/process.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-repairs-daemon.test.js`
+
+**Step 1: Write failing tests**
+
+Cover:
+
+- dead recorded PIDs permit stale state cleanup;
+- live unverified PIDs block repair and receive no signal;
+- absent daemon starts through an injected `ensureServer` seam;
+- both upstream and injector endpoints must answer;
+- no `terminal-browser open` process is spawned;
+- a second repair reports `unchanged`.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-repairs-daemon.test.js
+```
+
+Expected: FAIL because lifecycle repair is absent.
+
+**Step 3: Implement ownership-aware repair**
+
+Add a process identity abstraction that can be faked in tests. Only remove state when recorded PIDs are confirmed absent. Only signal a process after identity and expected endpoint checks agree. Use `ensureServer()` for startup after runtime/profile prerequisites are healthy, then verify `currentServer()` and both loopback ports.
+
+**Step 4: Run the focused test**
+
+Expected: PASS, especially the unverified-PID refusal case.
+
+## Task 15: Complete two-pass orchestration and idempotence
+
+**Objective:** Connect the repair registry to the orchestrator and make final checks, not initial checks, authoritative.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/orchestrator.ts`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/doctor/model.ts`
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-idempotence.test.js`
+
+**Step 1: Write failing tests**
+
+Run a disposable fixture through:
+
+1. initial checks;
+2. repair pass;
+3. final checks;
+4. second complete `--fix` pass.
+
+Assert that the second pass has zero changed actions and that unresolved shortcuts still return `2` while unrelated repairs are retained.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-idempotence.test.js
+```
+
+Expected: FAIL until repair actions are wired into the second-pass runner.
+
+**Step 3: Implement the full lifecycle**
+
+For `fix: false`, run checks once and return. For `fix: true`, run checks, select eligible actions, execute independent actions in dependency order, run all checks again, aggregate final status, and preserve all action outcomes in the report.
+
+**Step 4: Run the focused test**
+
+Expected: PASS with stable action ordering and no unnecessary writes.
+
+## Task 16: Add CLI integration and stdout/stderr contract tests
+
+**Objective:** Prove the actual built CLI is parseable and side-effect behavior is correct at the process boundary.
+
+**Files:**
+- Create: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/test/doctor-cli.test.js`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/package.json` only if a focused test script is genuinely needed; prefer the existing commands.
+
+**Step 1: Write failing tests**
+
+Spawn `/Users/pisitkoolplukpol/Work/terminal-code-doctor/dist/main.js` with isolated XDG paths and assert:
+
+- `doctor --json` stdout is exactly one parseable JSON document;
+- stderr does not make stdout invalid;
+- check-only mode leaves the fixture unchanged;
+- `doctor --json --fix` reports actions and final state;
+- exit codes `0`, `1`, `2`, and `64` map to the designed scenarios.
+
+**Step 2: Run to verify failure**
+
+```bash
+npm run -s build && node --test test/doctor-cli.test.js
+```
+
+Expected: FAIL until the complete CLI path is connected.
+
+**Step 3: Implement only missing boundary behavior**
+
+Do not duplicate checks in the subprocess test. Use injected fixture environment and fake release/process seams where possible; keep one smoke test for real command parsing and report serialization.
+
+**Step 4: Run the focused test**
+
+Expected: PASS.
+
+## Task 17: Document command behavior
+
+**Objective:** Make the new command discoverable and make its side effects and exit codes explicit.
+
+**Files:**
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/README.md`
+- Modify: `/Users/pisitkoolplukpol/Work/terminal-code-doctor/src/main.ts`
+
+**Step 1: Write documentation checks**
+
+Manually or with a small text assertion, verify README/help contains:
+
+- `tode doctor --json`;
+- `tode doctor --json --fix`;
+- stdout/stderr behavior;
+- exit codes;
+- `needs_input` shortcut behavior;
+- warning that `--fix` may download, modify managed config, and start the local daemon.
+
+**Step 2: Implement documentation**
+
+Keep the README example concise and link the JSON report contract to the command semantics. Do not promise unsupported terminal formats or automatic shortcut ownership decisions.
+
+**Step 3: Run documentation validation**
+
+```bash
+grep -nE 'tode doctor|needs_input|exit code|--fix' README.md src/main.ts
+```
+
+Expected: all required terms are present.
+
+## Task 18: Run the validation matrix
+
+**Objective:** Verify the complete feature without broad, repeated heavy runs.
+
+**Files:**
+- No new source files; validation only.
+
+**Step 1: Run focused doctor tests**
+
+```bash
+npm run -s build && node --test test/doctor*.test.js
+```
+
+Expected: all new doctor tests pass.
+
+**Step 2: Run type checking**
+
+```bash
+npm run typecheck
+```
+
+Expected: TypeScript and page type checks pass.
+
+**Step 3: Run the existing test suite**
+
+```bash
+npm test
+```
+
+Expected: existing tests and doctor tests pass after the build.
+
+**Step 4: Run repository hygiene checks**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intended files are modified/untracked.
+
+**Step 5: Run a minimal CLI smoke test**
+
+```bash
+node dist/main.js doctor --json > /tmp/tode-doctor.json
+python3 - <<'PY'
+import json
+with open('/tmp/tode-doctor.json', encoding='utf-8') as handle:
+    report = json.load(handle)
+assert report["schemaVersion"] == 1
+assert "checks" in report and "actions" in report
+print(report["summary"]["status"])
+PY
+```
+
+Expected: the report parses and contains schema version `1`, checks, actions, and summary status.
+
+## Completion checklist
+
+- [ ] `/Users/pisitkoolplukpol/Work/terminal-code-doctor/docs/superpowers/specs/2026-08-20-tode-doctor-json-design.md` remains unchanged after implementation unless the user approves a spec revision.
+- [ ] `tode doctor --json` is read-only.
+- [ ] `tode doctor --json --fix` records every action and performs a final verification pass.
+- [ ] Runtime downloads remain checksum-verified and never replace healthy pinned artifacts.
+- [ ] Profile repair preserves user-owned settings/keybindings.
+- [ ] Shortcut repair never guesses unresolved ownership and returns `needs_input`.
+- [ ] Daemon repair never signals an unverified PID or opens a terminal window.
+- [ ] A second identical repair run is idempotent.
+- [ ] JSON stdout is parseable and free of progress text.
+- [ ] Focused tests, typecheck, full tests, diff check, and CLI smoke validation pass.
+- [ ] No commit, push, PR, or deployment is performed without explicit user authorization.

--- a/docs/superpowers/specs/2026-08-20-tode-doctor-json-design.md
+++ b/docs/superpowers/specs/2026-08-20-tode-doctor-json-design.md
@@ -1,0 +1,427 @@
+# Design: `tode doctor --json` and `--fix`
+
+**Date:** 2026-08-20
+**Status:** Design approved for written-spec review
+**Repository:** `zenbu-labs/terminal-code`
+**Branch:** `feat/tode-doctor-json`
+
+## Problem
+
+`terminal-code` currently discovers and repairs parts of its installation opportunistically while opening the editor. Runtime resolution, code-server provisioning, profile generation, shortcut integration, and daemon startup are spread across the normal launch path. When one of those steps fails, users receive a narrow error from the operation that happened to encounter the problem rather than a complete diagnosis.
+
+This is particularly difficult for automated support and agent workflows. A caller needs a deterministic way to answer:
+
+- Which terminal-code capabilities are available on this machine?
+- Which local installation components are missing, stale, or unhealthy?
+- Which problems can be repaired safely without an interactive wizard?
+- What exactly changed after a repair attempt?
+- Which problems still require a human decision?
+
+The project needs a diagnostic command that can be used by a human, CI, or an agent without scraping prose or guessing from side effects.
+
+## Goals
+
+1. Add the canonical command:
+
+   ```text
+   tode doctor [--json] [--fix]
+   ```
+
+2. Make `--json` emit exactly one machine-readable JSON document on stdout.
+3. Keep progress, warnings, and debug details on stderr so stdout is safe to pipe into a parser.
+4. Make `doctor` without `--fix` observational: it must not download, write, start, stop, or modify anything.
+5. Make `doctor --fix` repair all deterministic problems within terminal-code's managed surface, including runtime, profile, supported terminal configuration, and the owned code-server/injector daemon.
+6. Re-run checks after repair and report both attempted actions and final state.
+7. Preserve non-interactive behavior. A shortcut conflict that has no saved decision must become `needs_input`; it must not be resolved by guessing.
+8. Make repairs idempotent: a second run after a successful repair should produce no unnecessary mutations.
+9. Reuse existing checksum, path, provider, profile, and server abstractions rather than creating parallel state formats.
+10. Give KiroCrew and other agents a stable, versioned capability/report contract.
+
+## Non-goals
+
+- Replacing the interactive `tode --shortcut-setup` wizard.
+- Choosing an owner for a shortcut conflict that the user has not decided.
+- Upgrading a healthy installation to a newer release. `doctor --fix` repairs the pinned/current installation; `tode --upgrade` remains the upgrade command.
+- Managing arbitrary user projects, VS Code extensions, shell dotfiles, or unrelated processes.
+- Exposing code-server beyond its existing localhost-only binding.
+- Executing arbitrary shell commands from report data or repair requests.
+- Adding a remote telemetry service or uploading diagnostic reports.
+
+## User-facing contract
+
+### Commands and flags
+
+The canonical forms are:
+
+```bash
+tode doctor
+tode doctor --json
+tode doctor --fix
+tode doctor --json --fix
+```
+
+`--json` and `--fix` may appear in either order. Unknown doctor flags are usage errors. The existing `tode` path-opening behavior remains unchanged for all other argument shapes.
+
+The help text must document `doctor`, `--json`, and `--fix`, including that `--fix` may download verified runtime artifacts, alter terminal-code-managed configuration, and start the owned local daemon.
+
+### Output channels
+
+For `--json`:
+
+- stdout contains one JSON document followed by one newline;
+- no progress, spinner, warning, or stack trace is written to stdout;
+- human-readable progress and diagnostics go to stderr;
+- errors are represented in the JSON report whenever report generation can continue.
+
+For non-JSON mode, the same report model is rendered as concise human-readable sections. The command must not have a separate diagnosis implementation for text mode.
+
+### Exit codes
+
+The command returns:
+
+- `0` when all checks are healthy after the optional repair pass;
+- `1` when a check or repair failed, or a final error remains;
+- `2` when a deterministic repair is blocked by a required user decision, including unresolved shortcut conflicts;
+- `64` for invalid command-line usage.
+
+The report always includes the selected exit code in `summary.exitCode`. If both a failed repair and `needs_input` are present, the failed-repair code `1` takes precedence.
+
+## Architecture
+
+The feature is a check/repair plan engine. The CLI adapter stays thin and the check/repair units are independently testable.
+
+### Proposed modules
+
+```text
+src/doctor/
+  model.ts          // public report, check, action, status types
+  context.ts        // read-only machine/install facts and dependency injection seams
+  checks.ts         // check registry and individual check implementations
+  repairs.ts        // repair registry and dependency-ordered actions
+  orchestrator.ts   // collect -> optionally repair -> collect again
+  report.ts         // JSON serialization and human rendering
+  doctor.ts         // command entrypoint and option validation
+```
+
+The exact file split may be adjusted during implementation if an existing module provides a better seam, but the responsibilities must remain separate:
+
+- checks never mutate state;
+- repairs declare their prerequisites and record outcomes;
+- orchestration owns ordering and the second verification pass;
+- rendering never performs checks or repairs.
+
+### Core model
+
+The model should use explicit string unions so the JSON contract is stable and TypeScript exhaustiveness checks catch new states.
+
+```ts
+type CheckStatus = "ok" | "warning" | "error" | "needs_input" | "skipped";
+type ActionStatus = "changed" | "unchanged" | "blocked" | "failed" | "skipped";
+type Severity = "info" | "warning" | "error";
+
+interface DoctorReport {
+  schemaVersion: 1;
+  command: {
+    fix: boolean;
+    json: boolean;
+  };
+  startedAt: string;
+  durationMs: number;
+  environment: EnvironmentSummary;
+  summary: {
+    status: CheckStatus;
+    checks: number;
+    ok: number;
+    warnings: number;
+    errors: number;
+    needsInput: number;
+    changed: number;
+    blocked: number;
+    failed: number;
+    exitCode: 0 | 1 | 2 | 64;
+  };
+  checks: DoctorCheck[];
+  actions: DoctorAction[];
+}
+
+interface DoctorCheck {
+  id: string;
+  status: CheckStatus;
+  severity: Severity;
+  fixable: boolean;
+  message: string;
+  details?: Record<string, unknown>;
+  actionIds?: string[];
+}
+
+interface DoctorAction {
+  id: string;
+  status: ActionStatus;
+  reversible: boolean;
+  message: string;
+  checkIds: string[];
+  details?: Record<string, unknown>;
+  error?: {
+    kind: string;
+    message: string;
+  };
+}
+```
+
+The report may include paths needed to understand an action, but it must not include secrets, complete environment dumps, shell command strings, access tokens, or arbitrary file contents. Sensitive paths should be redacted or represented by a stable category unless a future explicitly opt-in verbose mode is added.
+
+### Check registry
+
+Checks are run in deterministic order and receive a read-only context. The initial registry covers:
+
+1. `environment.platform`
+   - OS and supported target triple from the existing runtime abstraction;
+   - architecture;
+   - whether stdout/stderr/stdin are TTYs;
+   - whether the command is running in a context where interactive terminal queries are unavailable.
+
+2. `environment.terminal`
+   - detected Ghostty/Kitty provider, or unsupported/unknown terminal;
+   - provider readiness and reload hint;
+   - terminal palette query result when a TTY is available, with bounded timeouts;
+   - no terminal query may hang the command or change terminal configuration.
+
+3. `paths.managedState`
+   - required managed directories;
+   - install receipt/version/channel where available;
+   - readable/writable status without creating anything in check-only mode.
+
+4. `runtime.terminalBrowser`
+   - pinned version, target triple, source, and `usable()` result;
+   - vendored, pinned, system, override, and missing states;
+   - no release lookup or download during the check pass.
+
+5. `runtime.codeServer`
+   - configured/pinned code-server version and whether the executable is present and runnable;
+   - no provisioning during the check pass.
+
+6. `profile.generatedState`
+   - generated bridge, theme, CSS, settings, keybindings, font, and extension registration state that terminal-code owns;
+   - user-authored settings and extensions outside owned entries are not treated as repair targets.
+
+7. `shortcuts.configuration`
+   - provider detection and readiness;
+   - recorded decisions;
+   - current conflicts and whether each conflict has a saved decision;
+   - shared conflicts that can be auto-applied;
+   - unresolved conflicts are `needs_input`, not `error`, unless the provider itself is corrupt.
+
+8. `daemon.state`
+   - parse and freshness of the state file;
+   - ownership and liveness of the code-server and injector PIDs;
+   - localhost port responsiveness;
+   - stale state versus an actually healthy daemon.
+
+The check layer must not call `resolveRuntime`, `ensureCodeServer`, `ensureServer`, `installBridge`, `provider.apply`, or other mutating functions. It should use or introduce pure/read-only counterparts where current helpers combine observation and mutation.
+
+## Repair behavior
+
+`--fix` performs a repair pass only after the initial check pass has been collected. Each action is idempotent, has a stable ID, and records its result even when it fails. Independent actions continue after a failure; dependent actions are marked `skipped` or `blocked` with the dependency reason.
+
+### Repair order
+
+1. **Managed directories and state prerequisites**
+   - create only directories owned by terminal-code;
+   - never create or modify a user project directory;
+   - use the existing path abstraction so overrides remain respected.
+
+2. **Terminal-browser runtime**
+   - prefer an existing valid vendored, pinned, system, or explicitly configured override;
+   - if the pinned runtime is absent, use the existing verified release lookup/download/unpack path;
+   - preserve SHA-256 and size verification;
+   - remove incomplete or checksum-invalid temporary archives;
+   - never replace a valid runtime merely because a newer release exists.
+
+3. **Code-server runtime**
+   - use the existing pinned provisioning path;
+   - verify the executable after provisioning;
+   - report network, permission, or version failures without hiding the original cause.
+
+4. **Owned generated profile**
+   - regenerate only terminal-code-owned bridge, theme, CSS, settings, keybindings, extension registration, and font artifacts;
+   - preserve user-owned settings and unrelated keybindings;
+   - use existing write-if-changed behavior where available;
+   - use atomic writes for new repair code so interrupted repairs do not leave truncated JSON.
+
+5. **Terminal shortcuts**
+   - if a supported provider has saved decisions, apply those decisions through the existing provider abstraction;
+   - auto-apply only conflicts already classified as shared by the existing logic;
+   - if an unresolved conflict needs a user choice, record `needs_input` and do not mutate that conflict;
+   - if a provider is unsupported, report the capability and a remediation hint rather than writing an unknown config format;
+   - preserve the existing undo path and report whether a reload/restart is needed.
+
+6. **Daemon lifecycle**
+   - remove a stale state file only when its recorded processes are confirmed absent;
+   - never send a signal to a PID unless its identity is confirmed as a terminal-code-owned code-server/injector process;
+   - if the owned daemon is absent and prerequisites are healthy, start it through the existing server abstraction;
+   - verify both localhost endpoints after startup;
+   - do not launch a terminal-browser window;
+   - if a PID or port cannot be safely attributed, report `blocked` rather than killing or hijacking it.
+
+After all possible actions, the orchestrator runs the complete check registry again. The final checks, not the initial checks, determine the exit code and overall status. The report retains action results so a caller can distinguish a repaired warning from an unresolved failure.
+
+## JSON examples
+
+Healthy check-only invocation:
+
+```json
+{
+  "schemaVersion": 1,
+  "command": { "fix": false, "json": true },
+  "startedAt": "2026-08-20T00:00:00.000Z",
+  "durationMs": 42,
+  "environment": {
+    "platform": "darwin",
+    "architecture": "arm64",
+    "tty": true,
+    "terminalProvider": "ghostty"
+  },
+  "summary": {
+    "status": "ok",
+    "checks": 1,
+    "ok": 1,
+    "warnings": 0,
+    "errors": 0,
+    "needsInput": 0,
+    "changed": 0,
+    "blocked": 0,
+    "failed": 0,
+    "exitCode": 0
+  },
+  "checks": [
+    {
+      "id": "runtime.terminalBrowser",
+      "status": "ok",
+      "severity": "info",
+      "fixable": true,
+      "message": "pinned runtime is available"
+    }
+  ],
+  "actions": []
+}
+```
+
+A repair with an unresolved shortcut decision:
+
+```json
+{
+  "schemaVersion": 1,
+  "command": { "fix": true, "json": true },
+  "startedAt": "2026-08-20T00:00:00.000Z",
+  "durationMs": 812,
+  "environment": {
+    "platform": "darwin",
+    "architecture": "arm64",
+    "tty": true,
+    "terminalProvider": "ghostty"
+  },
+  "summary": {
+    "status": "needs_input",
+    "checks": 8,
+    "ok": 7,
+    "warnings": 0,
+    "errors": 0,
+    "needsInput": 1,
+    "changed": 2,
+    "blocked": 1,
+    "failed": 0,
+    "exitCode": 2
+  },
+  "checks": [
+    {
+      "id": "shortcuts.configuration",
+      "status": "needs_input",
+      "severity": "warning",
+      "fixable": false,
+      "message": "1 shortcut conflict has no saved decision",
+      "details": { "provider": "ghostty", "unresolved": 1 },
+      "actionIds": ["shortcuts.apply-decisions"]
+    }
+  ],
+  "actions": [
+    {
+      "id": "shortcuts.apply-decisions",
+      "status": "blocked",
+      "reversible": true,
+      "message": "left unresolved conflicts unchanged",
+      "checkIds": ["shortcuts.configuration"],
+      "details": { "reason": "needs_input" }
+    }
+  ]
+}
+```
+
+The examples are illustrative; the implementation must populate all summary counters consistently and must not omit real check entries. The healthy example shows one check for compactness, while an empty `actions` array is expected when no repair was requested or no mutation was needed.
+
+## Error handling and safety
+
+- Each check and action catches expected operational errors and converts them into typed report data.
+- Unexpected programming errors are reported as `failed` with a redacted message and also written to stderr in non-JSON mode.
+- Network failures identify the release operation and endpoint category but do not include credentials or response bodies.
+- Permission failures identify the managed category and path class without dumping file contents.
+- Failed downloads leave no accepted partial runtime; checksum failure is terminal for that action.
+- A repair pass never silently falls back to an interactive prompt.
+- Concurrent invocations must not corrupt shared state. New repair code should use existing lock/atomic patterns or fail with a clear busy result.
+- The daemon repair must not trust a PID solely because it is alive. PID identity and expected localhost endpoint must agree before any signal is sent.
+- The command must not expose code-server's local unauthenticated endpoint on a non-loopback address.
+
+## Testing strategy
+
+Tests should be deterministic and avoid live network, terminal graphics, or real daemon mutation.
+
+### Unit tests
+
+- option parsing for `doctor`, `--json`, `--fix`, ordering, unknown flags, and usage exit code;
+- check status aggregation and exit-code precedence;
+- JSON serialization is valid, stable, single-document output;
+- human and JSON reporters consume the same report model;
+- path/environment checks with fake filesystem facts;
+- runtime checks distinguish vendored, pinned, override, missing, and corrupt states;
+- repair ordering and dependency blocking;
+- action idempotence and write-if-changed behavior;
+- checksum failure removes incomplete artifacts;
+- shortcut saved-decision application and unresolved-conflict `needs_input` behavior;
+- daemon state parsing, endpoint checks, stale-state cleanup, and PID-ownership refusal;
+- no check-only operation writes, downloads, starts, stops, or mutates configuration.
+
+### Integration/CLI tests
+
+- `tode doctor --json` can be parsed from stdout while stderr contains no JSON contamination;
+- `tode doctor --json --fix` repairs a disposable fixture and a second run reports no changes;
+- a failed runtime download still produces a complete report and non-zero exit code;
+- a shortcut conflict requiring input repairs unrelated components but exits `2`;
+- daemon startup verifies both code-server and injector endpoints without opening a terminal window;
+- existing shortcut, profile, runtime, bridge, theme, and import tests remain green.
+
+The test harness should inject filesystem, network, process, terminal, and clock dependencies rather than patching global behavior. No test may use the user's real home, terminal config, or running daemon.
+
+## Acceptance criteria
+
+The implementation is complete when:
+
+1. `tode doctor --json` exists, is documented in help, and emits valid JSON with no side effects.
+2. `tode doctor --json --fix` performs the ordered repair pass and emits every action outcome.
+3. Runtime and code-server repair reuse verified existing provisioning paths and do not upgrade healthy installations.
+4. Profile repair preserves user-owned settings and keybindings.
+5. Supported terminal shortcut repair uses only saved decisions/shared auto-apply; unresolved choices remain unchanged and return `needs_input`.
+6. Daemon repair starts only owned local processes, never kills an unverified PID, and verifies both endpoints.
+7. A second identical `--fix` run is idempotent.
+8. JSON stdout is safe for CI/agent consumption and contains no secrets or arbitrary command text.
+9. Targeted tests cover all check and repair categories, and the repository's existing typecheck/build/test commands pass.
+10. README/help documentation explains side effects, exit codes, unsupported-terminal behavior, and the `needs_input` result.
+
+## Implementation sequencing
+
+1. Add the report model, dependency-injected context, option parser, and reporter with pure tests.
+2. Add read-only checks and check aggregation; wire `tode doctor` without repair.
+3. Add deterministic managed-state, runtime, code-server, and profile repairs.
+4. Add shortcut decision repair and explicit `needs_input` reporting.
+5. Add daemon ownership checks and lifecycle repair.
+6. Add CLI/integration tests, help/README documentation, and run the targeted validation matrix.
+
+No source implementation is part of this design-spec change. The next step is a detailed implementation plan after the user reviews this document.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -123,7 +123,7 @@ export function registerBridge(): void {
     const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
     if (Array.isArray(parsed)) listed = parsed;
   } catch {
-    return;
+    if (fs.existsSync(file)) return;
   }
   const entry: ExtensionEntry = {
     identifier: { id: BRIDGE_ID },
@@ -133,5 +133,5 @@ export function registerBridge(): void {
     metadata: { isApplicationScoped: false, isMachineScoped: false, installedTimestamp: 0 },
   };
   const without = listed.filter((item) => item.identifier?.id !== BRIDGE_ID);
-  fs.writeFileSync(file, `${JSON.stringify([...without, entry], null, 2)}\n`);
+  writeIfChanged(file, `${JSON.stringify([...without, entry], null, 2)}\n`);
 }

--- a/src/codeserver/server.ts
+++ b/src/codeserver/server.ts
@@ -48,6 +48,10 @@ function readState(): ServerState | null {
   }
 }
 
+export function readServerState(): ServerState | null {
+  return readState();
+}
+
 function writeState(state: ServerState) {
   fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
   fs.writeFileSync(STATE_FILE, `${JSON.stringify(state, null, 2)}\n`);

--- a/src/codeserver/vendored.ts
+++ b/src/codeserver/vendored.ts
@@ -45,6 +45,40 @@ export function installedCodeServer(): string | null {
   return binAt(codeServerRoot());
 }
 
+export interface CodeServerInspection {
+  source: "override" | "pinned" | "missing" | "invalid";
+  version: string;
+  root: string;
+  binary: string;
+  valid: boolean;
+  reason?: string;
+}
+
+export interface CodeServerInspectionOptions {
+  version?: string;
+  override?: string | null;
+  root?: string;
+  exists?: (file: string) => boolean;
+}
+
+export function inspectCodeServer(options: CodeServerInspectionOptions = {}): CodeServerInspection {
+  const version = options.version ?? CODE_SERVER_VERSION;
+  const override = options.override === undefined ? process.env.TODE_CODE_SERVER ?? null : options.override;
+  const root = options.root ?? codeServerRoot(version);
+  const exists = options.exists ?? fs.existsSync;
+  const binary = override ?? path.join(root, "bin", "code-server");
+  const valid = exists(binary);
+
+  return {
+    source: valid ? (override ? "override" : "pinned") : override ? "invalid" : "missing",
+    version,
+    root,
+    binary,
+    valid,
+    ...(valid ? {} : { reason: "code-server binary is not present" }),
+  };
+}
+
 export function narrateFetch(label: string): (fraction: number) => void {
   let announced = false;
   let lastPercent = -1;

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,0 +1,445 @@
+import path from "node:path";
+
+import { providerFor } from "../shortcuts/provider";
+import type { ShortcutProvider } from "../shortcuts/provider";
+import { loadDecisions } from "../shortcuts/store";
+import type { Decisions } from "../shortcuts/store";
+import { inspectCodeServer } from "../codeserver/vendored";
+import { answering, readServerState } from "../codeserver/server";
+import type { ServerState } from "../codeserver/server";
+import { systemProcessProbe, ownsServerProcess } from "./process";
+import { BRIDGE_DIR } from "../bridge";
+import { managedProfilePaths } from "../profile";
+import { inspectRuntime } from "../runtime/release";
+import type { DoctorContext } from "./context";
+import type { DoctorCheck } from "./model";
+
+const supportedPlatforms = new Set<NodeJS.Platform>(["darwin", "linux"]);
+
+export function checkEnvironment(context: DoctorContext): DoctorCheck[] {
+  const platformCheck: DoctorCheck = supportedPlatforms.has(context.environment.platform)
+    ? {
+        id: "environment.platform",
+        status: "ok",
+        severity: "info",
+        fixable: false,
+        message: `${context.environment.platform}-${context.environment.architecture} is supported`,
+        details: { targetTriple: context.environment.targetTriple },
+      }
+    : {
+        id: "environment.platform",
+        status: "error",
+        severity: "error",
+        fixable: false,
+        message: `${context.environment.platform} is not supported by terminal-code`,
+        details: { targetTriple: context.environment.targetTriple },
+      };
+
+  const ttyCheck: DoctorCheck = context.environment.tty.stdout
+    ? {
+        id: "environment.tty",
+        status: "ok",
+        severity: "info",
+        fixable: false,
+        message: "stdout is attached to a TTY",
+        details: { ...context.environment.tty },
+      }
+    : {
+        id: "environment.tty",
+        status: "warning",
+        severity: "warning",
+        fixable: false,
+        message: "stdout is not attached to a TTY; interactive terminal queries are unavailable",
+        details: { ...context.environment.tty },
+      };
+
+  const terminalCheck: DoctorCheck = context.environment.terminalProvider
+    ? {
+        id: "environment.terminal",
+        status: "ok",
+        severity: "info",
+        fixable: false,
+        message: `detected ${context.environment.terminalProvider.name}`,
+        details: { provider: context.environment.terminalProvider.id },
+      }
+    : {
+        id: "environment.terminal",
+        status: "warning",
+        severity: "warning",
+        fixable: false,
+        message: "no supported Ghostty or Kitty terminal was detected",
+      };
+
+  return [platformCheck, ttyCheck, terminalCheck];
+}
+
+export function checkTerminalBrowser(context: DoctorContext): DoctorCheck {
+  const result = inspectRuntime({ override: context.runtime.terminalBrowserOverride });
+  return {
+    id: "runtime.terminalBrowser",
+    status: result.valid ? "ok" : "error",
+    severity: result.valid ? "info" : "error",
+    fixable: true,
+    message: result.valid ? `terminal-browser ${result.version} is available` : result.reason ?? "terminal-browser is unavailable",
+    details: {
+      source: result.source,
+      version: result.version,
+      binary: result.binary,
+    },
+  };
+}
+
+export function checkCodeServer(context: DoctorContext): DoctorCheck {
+  const result = inspectCodeServer({
+    version: context.runtime.codeServerVersion,
+    override: context.runtime.codeServerOverride,
+  });
+  return {
+    id: "runtime.codeServer",
+    status: result.valid ? "ok" : "error",
+    severity: result.valid ? "info" : "error",
+    fixable: true,
+    message: result.valid ? `code-server ${result.version} is available` : result.reason ?? "code-server is unavailable",
+    details: {
+      source: result.source,
+      version: result.version,
+      binary: result.binary,
+    },
+  };
+}
+
+export function checkGeneratedProfile(context: DoctorContext): DoctorCheck {
+  const profile = managedProfilePaths();
+  const managedFiles: Record<string, string> = {
+    font: profile.font,
+    css: profile.css,
+    liveTheme: profile.liveTheme,
+    settings: profile.settings,
+    keybindingsRecord: profile.keybindingsRecord,
+    extensionsRegistry: profile.extensionsRegistry,
+    bridgeManifest: path.join(BRIDGE_DIR, "package.json"),
+    bridgeSource: path.join(BRIDGE_DIR, "extension.js"),
+  };
+  const missing = Object.entries(managedFiles)
+    .filter(([, file]) => !context.exists(file))
+    .map(([name]) => name);
+
+  if (missing.length === 0) {
+    return {
+      id: "profile.generatedState",
+      status: "ok",
+      severity: "info",
+      fixable: true,
+      message: "generated profile artifacts are present",
+    };
+  }
+
+  return {
+    id: "profile.generatedState",
+    status: "warning",
+    severity: "warning",
+    fixable: true,
+    message: `${missing.length} generated profile artifact${missing.length === 1 ? " is" : "s are"} missing`,
+    details: { missing },
+  };
+}
+
+export interface ShortcutCheckOptions {
+  provider?: ShortcutProvider | null;
+  decisions?: Decisions | null;
+}
+
+function hasRecordedDecision(conflictId: string, decisions: Decisions | null): boolean {
+  const choices = decisions?.choices ?? {};
+  return Boolean(
+    choices[conflictId] ||
+      choices[`import:${conflictId}`] ||
+      Object.keys(choices).some((id) => id.startsWith(`claim:${conflictId}`)),
+  );
+}
+
+export function checkShortcuts(
+  context: DoctorContext,
+  options: ShortcutCheckOptions = {},
+): DoctorCheck {
+  const provider = options.provider === undefined ? providerFor() : options.provider;
+  const decisions = options.decisions === undefined ? loadDecisions() : options.decisions;
+
+  if (!provider) {
+    return {
+      id: "shortcuts.configuration",
+      status: "warning",
+      severity: "warning",
+      fixable: false,
+      message: "shortcut setup is unavailable for the detected terminal",
+      details: { provider: context.environment.terminalProvider?.id ?? null },
+    };
+  }
+
+  const notReady = provider.ready();
+  if (notReady) {
+    return {
+      id: "shortcuts.configuration",
+      status: "warning",
+      severity: "warning",
+      fixable: false,
+      message: notReady,
+      details: { provider: provider.id },
+    };
+  }
+
+  let conflicts;
+  try {
+    conflicts = provider.scan();
+  } catch (error) {
+    return {
+      id: "shortcuts.configuration",
+      status: "error",
+      severity: "error",
+      fixable: false,
+      message: error instanceof Error ? error.message : String(error),
+      details: { provider: provider.id },
+    };
+  }
+
+  const unresolved = conflicts.filter(
+    (conflict) => !conflict.shared && !hasRecordedDecision(conflict.editorId, decisions),
+  );
+  const fixable = conflicts.length > 0 && unresolved.length === 0;
+
+  if (unresolved.length > 0) {
+    return {
+      id: "shortcuts.configuration",
+      status: "needs_input",
+      severity: "warning",
+      fixable: false,
+      message: `${unresolved.length} shortcut conflict${unresolved.length === 1 ? " has" : "s have"} no saved decision`,
+      details: {
+        provider: provider.id,
+        conflicts: conflicts.length,
+        unresolved: unresolved.length,
+      },
+      actionIds: ["shortcuts.apply-decisions"],
+    };
+  }
+
+  return {
+    id: "shortcuts.configuration",
+    status: conflicts.length === 0 ? "ok" : "warning",
+    severity: conflicts.length === 0 ? "info" : "warning",
+    fixable,
+    message:
+      conflicts.length === 0
+        ? "no unresolved shortcut conflicts detected"
+        : `${conflicts.length} shortcut conflict${conflicts.length === 1 ? " is" : "s are"} ready for saved-decision repair`,
+    details: { provider: provider.id, conflicts: conflicts.length },
+    actionIds: fixable ? ["shortcuts.apply-decisions"] : undefined,
+  };
+}
+
+export interface DaemonCheckOptions {
+  state?: ServerState | null;
+  alive?: (pid: number) => boolean;
+  command?: (pid: number) => string | null;
+  probePort?: (port: number) => Promise<boolean>;
+  portOwner?: (port: number) => number | null;
+}
+
+function validServerState(state: ServerState | null): state is ServerState {
+  return !!state &&
+    Number.isInteger(state.pid) && state.pid > 0 &&
+    Number.isInteger(state.injectorPid) && state.injectorPid > 0 &&
+    Number.isInteger(state.port) && state.port > 0 && state.port < 65536 &&
+    Number.isInteger(state.injectorPort) && state.injectorPort > 0 && state.injectorPort < 65536 &&
+    typeof state.version === "string";
+}
+
+export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<DoctorCheck> {
+  const state = options.state === undefined ? readServerState() : options.state;
+  if (!state) {
+    return {
+      id: "daemon.state",
+      status: "warning",
+      severity: "warning",
+      fixable: true,
+      message: "terminal-code daemon is not running",
+    };
+  }
+
+  if (!validServerState(state)) {
+    return {
+      id: "daemon.state",
+      status: "error",
+      severity: "error",
+      fixable: false,
+      message: "daemon state is malformed and cannot be safely repaired",
+    };
+  }
+
+  const probe = {
+    alive: options.alive ?? systemProcessProbe.alive,
+    command: options.command ?? systemProcessProbe.command,
+    port: options.probePort ?? answering,
+  };
+  const processes = [
+    { kind: "code-server" as const, pid: state.pid },
+    { kind: "injector" as const, pid: state.injectorPid },
+  ];
+  const dead = processes.filter(({ pid }) => !probe.alive(pid));
+  if (dead.length > 0) {
+    return {
+      id: "daemon.state",
+      status: "warning",
+      severity: "warning",
+      fixable: true,
+      message: "daemon state references a stopped process",
+      details: { deadPids: dead.map(({ pid }) => pid) },
+    };
+  }
+
+  const unowned = processes.filter(
+    ({ kind, pid }) => !ownsServerProcess(kind, state, probe.command(pid)),
+  );
+  if (unowned.length > 0) {
+    return {
+      id: "daemon.state",
+      status: "error",
+      severity: "error",
+      fixable: false,
+      message: "daemon state references a process that cannot be verified as terminal-code-owned",
+      details: { unownedPids: unowned.map(({ pid }) => pid) },
+    };
+  }
+
+  const portOwner = options.portOwner ?? systemProcessProbe.portOwner;
+  if (portOwner) {
+    const occupied = [state.port, state.injectorPort]
+      .map((port) => ({ port, pid: portOwner(port) }))
+      .filter(({ pid }) => pid !== null && pid !== state.pid && pid !== state.injectorPid);
+    if (occupied.length > 0) {
+      return {
+        id: "daemon.state",
+        status: "error",
+        severity: "error",
+        fixable: false,
+        message: "a daemon localhost port is occupied by an unattributed process",
+        details: { occupiedPorts: occupied.map(({ port, pid }) => ({ port, pid })) },
+      };
+    }
+  }
+
+  const [upstream, injector] = await Promise.all([
+    probe.port(state.port),
+    probe.port(state.injectorPort),
+  ]);
+  if (!upstream || !injector) {
+    return {
+      id: "daemon.state",
+      status: "error",
+      severity: "error",
+      fixable: true,
+      message: "owned daemon processes are alive but a localhost endpoint is not responding",
+      details: { upstream, injector },
+    };
+  }
+
+  return {
+    id: "daemon.state",
+    status: "ok",
+    severity: "info",
+    fixable: true,
+    message: "owned code-server and injector daemon are healthy",
+    details: { port: state.port, injectorPort: state.injectorPort },
+  };
+}
+
+const managedDirectories = (context: DoctorContext): Record<string, string> => ({
+  data: context.paths.data,
+  state: context.paths.state,
+  cache: context.paths.cache,
+  runtime: context.paths.runtime,
+  logs: context.paths.logs,
+});
+
+export function checkManagedState(context: DoctorContext): DoctorCheck {
+  const missing = Object.entries(managedDirectories(context))
+    .filter(([, directory]) => !context.exists(directory))
+    .map(([name]) => name);
+
+  if (missing.length === 0) {
+    return {
+      id: "paths.managedState",
+      status: "ok",
+      severity: "info",
+      fixable: true,
+      message: "managed directories are present",
+    };
+  }
+
+  return {
+    id: "paths.managedState",
+    status: "warning",
+    severity: "warning",
+    fixable: true,
+    message: `${missing.length} managed director${missing.length === 1 ? "y is" : "ies are"} missing`,
+    details: { missing },
+  };
+}
+
+export function collectReadOnlyChecks(context: DoctorContext): DoctorCheck[] {
+  return [
+    ...checkEnvironment(context),
+    checkManagedState(context),
+    checkTerminalBrowser(context),
+    checkCodeServer(context),
+    checkGeneratedProfile(context),
+    checkShortcuts(context),
+  ];
+}
+
+export interface CheckRegistryOptions {
+  daemon?: DaemonCheckOptions;
+  shortcuts?: ShortcutCheckOptions;
+}
+
+function checkFailure(id: string, error: unknown): DoctorCheck {
+  return {
+    id,
+    status: "error",
+    severity: "error",
+    fixable: false,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export async function collectDoctorChecks(
+  context: DoctorContext,
+  options: CheckRegistryOptions = {},
+): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+  try {
+    checks.push(...checkEnvironment(context));
+  } catch (error) {
+    checks.push(checkFailure("environment", error));
+  }
+  const entries: [string, () => DoctorCheck][] = [
+    ["paths.managedState", () => checkManagedState(context)],
+    ["runtime.terminalBrowser", () => checkTerminalBrowser(context)],
+    ["runtime.codeServer", () => checkCodeServer(context)],
+    ["profile.generatedState", () => checkGeneratedProfile(context)],
+    ["shortcuts.configuration", () => checkShortcuts(context, options.shortcuts)],
+  ];
+  for (const [id, run] of entries) {
+    try {
+      checks.push(run());
+    } catch (error) {
+      checks.push(checkFailure(id, error));
+    }
+  }
+  try {
+    checks.push(await checkDaemon(options.daemon));
+  } catch (error) {
+    checks.push(checkFailure("daemon.state", error));
+  }
+  return checks;
+}

--- a/src/doctor/command.ts
+++ b/src/doctor/command.ts
@@ -1,0 +1,27 @@
+export interface DoctorOptions {
+  json: boolean;
+  fix: boolean;
+}
+
+export type DoctorArgs =
+  | { kind: "ok"; options: DoctorOptions }
+  | { kind: "usage-error"; message: string };
+
+export function parseDoctorArgs(args: readonly string[]): DoctorArgs {
+  let json = false;
+  let fix = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--fix") {
+      fix = true;
+      continue;
+    }
+    return { kind: "usage-error", message: `unknown doctor option ${arg}` };
+  }
+
+  return { kind: "ok", options: { json, fix } };
+}

--- a/src/doctor/context.ts
+++ b/src/doctor/context.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+
+import { CODE_SERVER_VERSION, codeServerRoot, installedCodeServer } from "../codeserver/vendored";
+import { providerFor } from "../shortcuts/provider";
+import {
+  BROWSER_HOME,
+  CACHE_DIR,
+  DATA_DIR,
+  INSTALL_ROOT,
+  LOGS_DIR,
+  RUNTIME_DIR,
+  STATE_DIR,
+  VENDOR_DIR,
+} from "../runtime/paths";
+import { PINNED_VERSION, targetTriple } from "../runtime/release";
+
+export interface DoctorTty {
+  stdin: boolean;
+  stdout: boolean;
+  stderr: boolean;
+}
+
+export interface DoctorContextOptions {
+  env?: NodeJS.ProcessEnv;
+  tty?: Partial<DoctorTty>;
+  exists?: (file: string) => boolean;
+  codeServerBinary?: string | null;
+}
+
+export interface DoctorContext {
+  environment: {
+    platform: NodeJS.Platform;
+    architecture: string;
+    targetTriple: string;
+    tty: DoctorTty;
+    terminalProvider: { id: string; name: string } | null;
+  };
+  paths: {
+    install: string;
+    vendor: string;
+    data: string;
+    state: string;
+    cache: string;
+    runtime: string;
+    logs: string;
+    codeServer: string;
+    browser: typeof BROWSER_HOME;
+  };
+  runtime: {
+    terminalBrowserVersion: string;
+    terminalBrowserOverride: string | null;
+    codeServerVersion: string;
+    codeServerOverride: string | null;
+    codeServerBinary: string | null;
+  };
+  exists: (file: string) => boolean;
+}
+
+function processTty(): DoctorTty {
+  return {
+    stdin: Boolean(process.stdin.isTTY),
+    stdout: Boolean(process.stdout.isTTY),
+    stderr: Boolean(process.stderr.isTTY),
+  };
+}
+
+export function collectDoctorContext(options: DoctorContextOptions = {}): DoctorContext {
+  const env = options.env ?? process.env;
+  const tty = { ...processTty(), ...options.tty };
+  const provider = providerFor(env);
+  const configuredCodeServer = env.TODE_CODE_SERVER ?? null;
+  const codeServerBinary =
+    options.codeServerBinary !== undefined
+      ? options.codeServerBinary
+      : env === process.env
+        ? installedCodeServer()
+        : configuredCodeServer;
+
+  return {
+    environment: {
+      platform: process.platform,
+      architecture: process.arch,
+      targetTriple: targetTriple(),
+      tty,
+      terminalProvider: provider ? { id: provider.id, name: provider.name } : null,
+    },
+    paths: {
+      install: INSTALL_ROOT,
+      vendor: VENDOR_DIR,
+      data: DATA_DIR,
+      state: STATE_DIR,
+      cache: CACHE_DIR,
+      runtime: RUNTIME_DIR,
+      logs: LOGS_DIR,
+      codeServer: codeServerRoot(),
+      browser: BROWSER_HOME,
+    },
+    runtime: {
+      terminalBrowserVersion: PINNED_VERSION,
+      terminalBrowserOverride: env.TODE_TERMINAL_BROWSER_BIN ?? null,
+      codeServerVersion: CODE_SERVER_VERSION,
+      codeServerOverride: configuredCodeServer,
+      codeServerBinary,
+    },
+    exists: options.exists ?? fs.existsSync,
+  };
+}

--- a/src/doctor/model.ts
+++ b/src/doctor/model.ts
@@ -1,0 +1,91 @@
+export type CheckStatus = "ok" | "warning" | "error" | "needs_input" | "skipped";
+export type ActionStatus = "changed" | "unchanged" | "blocked" | "failed" | "skipped";
+export type Severity = "info" | "warning" | "error";
+export type DoctorExitCode = 0 | 1 | 2 | 64;
+
+export interface DoctorCheck {
+  id: string;
+  status: CheckStatus;
+  severity: Severity;
+  fixable: boolean;
+  message: string;
+  details?: Record<string, unknown>;
+  actionIds?: string[];
+}
+
+export interface DoctorAction {
+  id: string;
+  status: ActionStatus;
+  reversible: boolean;
+  message: string;
+  checkIds: string[];
+  details?: Record<string, unknown>;
+  error?: {
+    kind: string;
+    message: string;
+  };
+}
+
+export interface DoctorSummary {
+  status: CheckStatus;
+  checks: number;
+  ok: number;
+  warnings: number;
+  errors: number;
+  needsInput: number;
+  changed: number;
+  blocked: number;
+  failed: number;
+  exitCode: DoctorExitCode;
+}
+
+export interface EnvironmentSummary {
+  platform: string;
+  architecture: string;
+  tty: boolean;
+  terminalProvider: string | null;
+}
+
+export interface DoctorReport {
+  schemaVersion: 1;
+  command: {
+    fix: boolean;
+    json: boolean;
+  };
+  startedAt: string;
+  durationMs: number;
+  environment: EnvironmentSummary;
+  summary: DoctorSummary;
+  checks: DoctorCheck[];
+  actions: DoctorAction[];
+}
+
+export function summarize(checks: DoctorCheck[], actions: DoctorAction[]): DoctorSummary {
+  const errors = checks.filter((check) => check.status === "error").length;
+  const warnings = checks.filter((check) => check.status === "warning").length;
+  const needsInput = checks.filter((check) => check.status === "needs_input").length;
+  const failed = actions.filter((action) => action.status === "failed").length;
+  const changed = actions.filter((action) => action.status === "changed").length;
+  const blocked = actions.filter((action) => action.status === "blocked").length;
+  const ok = checks.filter((check) => check.status === "ok").length;
+
+  const blockedNeedsInput = actions.some(
+    (action) => action.status === "blocked" && action.details?.reason === "needs_input",
+  );
+  const exitCode: DoctorExitCode = errors > 0 || failed > 0 ? 1 : needsInput > 0 || blockedNeedsInput ? 2 : 0;
+  const status: CheckStatus =
+    exitCode === 1 ? "error" : exitCode === 2 ? "needs_input" : warnings > 0 ? "warning" : "ok";
+
+  return {
+    status,
+    checks: checks.length,
+    ok,
+    warnings,
+    errors,
+    needsInput,
+    changed,
+    blocked,
+    failed,
+    exitCode,
+  };
+}

--- a/src/doctor/orchestrator.ts
+++ b/src/doctor/orchestrator.ts
@@ -1,0 +1,109 @@
+import { collectDoctorContext } from "./context";
+import { collectDoctorChecks } from "./checks";
+import type { CheckRegistryOptions } from "./checks";
+import type { DoctorContext } from "./context";
+import { makeDoctorReport } from "./report";
+import type { DoctorReport } from "./model";
+import type { DoctorAction, DoctorCheck } from "./model";
+import { repairChecks } from "./repairs";
+import type { RepairDependencies } from "./repairs";
+
+export interface DoctorRunnerOptions {
+  json: boolean;
+  fix: boolean;
+}
+
+export interface DoctorRunnerDependencies {
+  context?: DoctorContext;
+  collectChecks?: (context: DoctorContext) => Promise<DoctorCheck[]>;
+  checkOptions?: CheckRegistryOptions;
+  repairChecks?: (
+    checks: DoctorCheck[],
+    context: DoctorContext,
+    dependencies: RepairDependencies,
+  ) => Promise<DoctorAction[]>;
+  repairDependencies?: RepairDependencies;
+  now?: () => number;
+  stderr?: (message: string) => void;
+}
+
+function checkFailure(id: string, error: unknown): DoctorCheck {
+  return {
+    id,
+    status: "error",
+    severity: "error",
+    fixable: false,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+async function collect(
+  context: DoctorContext,
+  collector: (context: DoctorContext) => Promise<DoctorCheck[]>,
+): Promise<DoctorCheck[]> {
+  try {
+    return await collector(context);
+  } catch (error) {
+    return [checkFailure("doctor.checks", error)];
+  }
+}
+
+export async function runDoctor(
+  options: DoctorRunnerOptions,
+  dependencies: DoctorRunnerDependencies = {},
+): Promise<DoctorReport> {
+  const now = dependencies.now ?? Date.now;
+  const startedAtMs = now();
+  const startedAt = new Date(startedAtMs).toISOString();
+  const context = dependencies.context ?? collectDoctorContext();
+  const collector = dependencies.collectChecks ?? ((value: DoctorContext) => collectDoctorChecks(value, dependencies.checkOptions));
+  const repairer = dependencies.repairChecks ?? repairChecks;
+  const stderr = dependencies.stderr ?? ((message: string) => process.stderr.write(message));
+  const repairDependencies: RepairDependencies = {
+    ...(dependencies.repairDependencies ?? {}),
+    stderr: dependencies.repairDependencies?.stderr ?? stderr,
+  };
+
+  const initialChecks = await collect(context, collector);
+  let actions: DoctorAction[] = [];
+  let finalChecks = initialChecks;
+  if (options.fix) {
+    try {
+      actions = await repairer(initialChecks, context, repairDependencies);
+    } catch (error) {
+      actions = [
+        {
+          id: "doctor.repairs",
+          status: "failed",
+          reversible: false,
+          message: error instanceof Error ? error.message : String(error),
+          checkIds: [],
+          error: {
+            kind: error instanceof Error ? error.name : "Error",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        },
+      ];
+    }
+    finalChecks = await collect(context, collector);
+  }
+
+  return makeDoctorReport({
+    command: options,
+    context,
+    startedAt,
+    durationMs: now() - startedAtMs,
+    checks: finalChecks,
+    actions,
+  });
+}
+
+export interface DoctorRunner {
+  run(options: DoctorRunnerOptions): Promise<DoctorReport>;
+}
+
+export function createDoctorRunner(
+  dependencies: DoctorRunnerDependencies = {},
+): DoctorRunner {
+  return { run: (options) => runDoctor(options, dependencies) };
+}

--- a/src/doctor/process.ts
+++ b/src/doctor/process.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from "node:child_process";
+
+import type { ServerState } from "../codeserver/server";
+
+export type OwnedProcessKind = "code-server" | "injector";
+
+export interface ProcessProbe {
+  alive(pid: number): boolean;
+  command(pid: number): string | null;
+  portOwner?(port: number): number | null;
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function command(pid: number): string | null {
+  try {
+    return execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function portOwner(port: number): number | null {
+  try {
+    const output = execFileSync(
+      "lsof",
+      ["-nP", "-a", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fp"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const match = /^p(\\d+)$/m.exec(output);
+    return match ? Number(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export const systemProcessProbe: ProcessProbe = { alive, command, portOwner };
+
+export function ownsServerProcess(
+  kind: OwnedProcessKind,
+  state: ServerState,
+  commandLine: string | null,
+): boolean {
+  if (!commandLine) return false;
+  if (kind === "code-server") {
+    return (
+      commandLine.includes("code-server") &&
+      commandLine.includes("--app-name") &&
+      commandLine.includes("tode") &&
+      commandLine.includes(`127.0.0.1:${state.port}`)
+    );
+  }
+  return (
+    commandLine.includes("injector-main.js") &&
+    commandLine.includes(String(state.port)) &&
+    commandLine.includes(String(state.injectorPort))
+  );
+}

--- a/src/doctor/repairs.ts
+++ b/src/doctor/repairs.ts
@@ -1,0 +1,507 @@
+import fs from "node:fs";
+
+import {
+  answering,
+  currentServer,
+  ensureServer,
+  readServerState,
+  stopServer,
+  STATE_FILE,
+} from "../codeserver/server";
+import type { ServerState } from "../codeserver/server";
+import { ensureCodeServer } from "../codeserver/vendored";
+import { installBridge } from "../bridge";
+import {
+  ensureFont,
+  installCss,
+  installKeybindings,
+  installSettings,
+  installTheme,
+  readPalette,
+  setLiveTheme,
+} from "../profile";
+import { generateTheme } from "../theme/generate";
+import { providerFor } from "../shortcuts/provider";
+import type { ProviderConflict, ShortcutProvider } from "../shortcuts/provider";
+import { applyRecordedDecisions } from "../shortcuts/wizard";
+import { loadDecisions } from "../shortcuts/store";
+import type { Decision } from "../shortcuts/store";
+import { resolveRuntime } from "../runtime/release";
+import type { ResolveOptions } from "../runtime/release";
+import type { DoctorContext } from "./context";
+import { ownsServerProcess, systemProcessProbe } from "./process";
+import type { ProcessProbe } from "./process";
+import type { DoctorAction, DoctorCheck } from "./model";
+
+export interface RepairDependencies {
+  mkdir?: (directory: string) => void;
+  resolveRuntime?: (options?: ResolveOptions) => Promise<unknown>;
+  ensureCodeServer?: (onProgress?: (fraction: number) => void) => Promise<string>;
+  readPalette?: typeof readPalette;
+  ensureFont?: typeof ensureFont;
+  installTheme?: typeof installTheme;
+  installCss?: typeof installCss;
+  setLiveTheme?: typeof setLiveTheme;
+  installSettings?: typeof installSettings;
+  installKeybindings?: typeof installKeybindings;
+  installBridge?: typeof installBridge;
+  todeCommand?: () => string[];
+  provider?: ShortcutProvider | null;
+  applyRecordedDecisions?: typeof applyRecordedDecisions;
+  readServerState?: () => ServerState | null;
+  removeServerState?: () => void;
+  ensureServer?: () => Promise<ServerState>;
+  currentServer?: typeof currentServer;
+  stopServer?: () => boolean;
+  processProbe?: ProcessProbe;
+  probePort?: (port: number) => Promise<boolean>;
+  portOwner?: (port: number) => number | null;
+  sleep?: (milliseconds: number) => Promise<void>;
+  daemonStartupTimeoutMs?: number;
+  stderr?: (message: string) => void;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function failedAction(id: string, checkIds: string[], error: unknown, reversible = false): DoctorAction {
+  return {
+    id,
+    status: "failed",
+    reversible,
+    message: errorMessage(error),
+    checkIds,
+    error: { kind: error instanceof Error ? error.name : "Error", message: errorMessage(error) },
+  };
+}
+
+function resultAction(
+  id: string,
+  changed: boolean,
+  message: string,
+  checkIds: string[],
+  details: Record<string, unknown> = {},
+  reversible = true,
+): DoctorAction {
+  return {
+    id,
+    status: changed ? "changed" : "unchanged",
+    reversible,
+    message,
+    checkIds,
+    ...(Object.keys(details).length > 0 ? { details } : {}),
+  };
+}
+
+function blockedAction(
+  id: string,
+  message: string,
+  checkIds: string[],
+  details: Record<string, unknown> = {},
+): DoctorAction {
+  return {
+    id,
+    status: "blocked",
+    reversible: true,
+    message,
+    checkIds,
+    ...(Object.keys(details).length > 0 ? { details } : {}),
+  };
+}
+
+function progress(stderr: ((message: string) => void) | undefined, label: string) {
+  let announced = false;
+  let lastPercent = -1;
+  return (fraction: number) => {
+    if (!stderr) return;
+    if (!announced) {
+      stderr(`tode: repairing ${label}\n`);
+      announced = true;
+    }
+    const percent = Math.round(fraction * 100);
+    if (percent === lastPercent) return;
+    lastPercent = percent;
+    stderr(`tode: ${label} ${percent}%\n`);
+  };
+}
+
+function checkFor(checks: DoctorCheck[], id: string): DoctorCheck | undefined {
+  return checks.find((check) => check.id === id);
+}
+
+function shouldRepair(check: DoctorCheck | undefined): boolean {
+  return !!check && check.status !== "ok" && check.fixable;
+}
+
+async function repairManagedState(
+  context: DoctorContext,
+  check: DoctorCheck,
+  deps: RepairDependencies,
+): Promise<DoctorAction> {
+  const mkdir = deps.mkdir ?? ((directory: string) => fs.mkdirSync(directory, { recursive: true }));
+  const names: Record<string, string> = {
+    data: context.paths.data,
+    state: context.paths.state,
+    cache: context.paths.cache,
+    runtime: context.paths.runtime,
+    logs: context.paths.logs,
+  };
+  const created: string[] = [];
+  try {
+    for (const [name, directory] of Object.entries(names)) {
+      if (context.exists(directory)) continue;
+      mkdir(directory);
+      created.push(name);
+    }
+    return resultAction(
+      "paths.create-managed-directories",
+      created.length > 0,
+      created.length > 0 ? "created missing managed directories" : "managed directories are already present",
+      [check.id],
+      { created },
+      true,
+    );
+  } catch (error) {
+    return failedAction("paths.create-managed-directories", [check.id], error, true);
+  }
+}
+
+async function repairRuntime(
+  check: DoctorCheck,
+  deps: RepairDependencies,
+): Promise<DoctorAction> {
+  try {
+    const resolve = deps.resolveRuntime ?? ((options?: ResolveOptions) => resolveRuntime(options));
+    const onProgress = progress(deps.stderr, "terminal-browser");
+    await resolve({ onProgress: (_stage, fraction) => onProgress(fraction) });
+    return resultAction(
+      "runtime.terminalBrowser.repair",
+      true,
+      "terminal-browser runtime is available",
+      [check.id],
+      {},
+      false,
+    );
+  } catch (error) {
+    return failedAction("runtime.terminalBrowser.repair", [check.id], error, false);
+  }
+}
+
+async function repairCodeServer(
+  check: DoctorCheck,
+  deps: RepairDependencies,
+): Promise<DoctorAction> {
+  try {
+    const ensure = deps.ensureCodeServer ?? ensureCodeServer;
+    await ensure(progress(deps.stderr, "code-server"));
+    return resultAction(
+      "runtime.codeServer.repair",
+      true,
+      "code-server runtime is available",
+      [check.id],
+      {},
+      false,
+    );
+  } catch (error) {
+    return failedAction("runtime.codeServer.repair", [check.id], error, false);
+  }
+}
+
+async function repairProfile(
+  check: DoctorCheck,
+  deps: RepairDependencies,
+): Promise<DoctorAction[]> {
+  const readPaletteFn = deps.readPalette ?? readPalette;
+  const ensureFontFn = deps.ensureFont ?? ensureFont;
+  const installThemeFn = deps.installTheme ?? installTheme;
+  const installCssFn = deps.installCss ?? installCss;
+  const setLiveThemeFn = deps.setLiveTheme ?? setLiveTheme;
+  const installSettingsFn = deps.installSettings ?? installSettings;
+  const installKeybindingsFn = deps.installKeybindings ?? installKeybindings;
+  const installBridgeFn = deps.installBridge ?? installBridge;
+  const command = deps.todeCommand ?? (() => [process.execPath, process.argv[1] ?? "tode"]);
+
+  try {
+    const { palette } = await readPaletteFn();
+    const font = ensureFontFn();
+    const theme = installThemeFn(palette);
+    const cssChanged = installCssFn(palette);
+    const liveThemeChanged = setLiveThemeFn(generateTheme(palette));
+    const settingsChanged = installSettingsFn();
+    const keybindingsChanged = installKeybindingsFn();
+    const bridgeChanged = installBridgeFn(command());
+    return [
+      resultAction("profile.font", font === "installed", font === "installed" ? "installed managed font" : "managed font is present", [check.id], { state: font }),
+      resultAction("profile.theme", theme.changed, theme.changed ? "generated managed theme" : "managed theme is current", [check.id], { fingerprint: theme.fingerprint }),
+      resultAction("profile.css", cssChanged, cssChanged ? "generated managed CSS" : "managed CSS is current", [check.id]),
+      resultAction("profile.live-theme", liveThemeChanged, liveThemeChanged ? "updated live theme" : "live theme is current", [check.id]),
+      resultAction("profile.settings", settingsChanged, settingsChanged ? "updated managed settings" : "managed settings are current", [check.id]),
+      resultAction("profile.keybindings", keybindingsChanged, keybindingsChanged ? "updated managed keybindings" : "managed keybindings are current", [check.id]),
+      resultAction("profile.bridge", bridgeChanged, bridgeChanged ? "generated bridge extension" : "bridge extension is current", [check.id]),
+    ];
+  } catch (error) {
+    return [failedAction("profile.generatedState.repair", [check.id], error, true)];
+  }
+}
+
+function hasDecision(conflict: ProviderConflict, choices: Record<string, Decision>): boolean {
+  return Boolean(
+    choices[conflict.editorId] ||
+      choices[`import:${conflict.editorId}`] ||
+      Object.keys(choices).some((id) => id.startsWith(`claim:${conflict.editorId}`)),
+  );
+}
+
+function relevantDecision(conflict: ProviderConflict, choices: Record<string, Decision>): boolean {
+  const decision = choices[conflict.editorId];
+  return decision?.choice === "terminal" || decision?.choice === "editor" || decision?.choice === "keep" || hasDecision(conflict, choices);
+}
+
+function repairShortcuts(
+  check: DoctorCheck,
+  deps: RepairDependencies,
+): DoctorAction[] {
+  const provider = deps.provider === undefined ? providerFor() : deps.provider;
+  if (!provider) {
+    return [blockedAction("shortcuts.apply-decisions", "shortcut provider is unavailable", [check.id], { reason: "unsupported-provider" })];
+  }
+  try {
+    const ready = provider.ready();
+    if (ready) {
+      return [blockedAction("shortcuts.apply-decisions", ready, [check.id], { provider: provider.id })];
+    }
+    const conflicts = provider.scan();
+    const choices = { ...(loadDecisions()?.choices ?? {}) };
+    const unresolved = conflicts.filter(
+      (conflict) => !conflict.shared && !hasDecision(conflict, choices),
+    );
+    const freshShared = conflicts.filter(
+      (conflict) => conflict.shared && conflict.current !== null && !choices[conflict.editorId],
+    );
+    for (const conflict of freshShared) {
+      choices[conflict.editorId] = { choice: "terminal", action: conflict.current ?? undefined };
+    }
+    const applicable = conflicts.some((conflict) => relevantDecision(conflict, choices));
+    const actions: DoctorAction[] = [];
+    if (applicable) {
+      const apply = deps.applyRecordedDecisions ?? applyRecordedDecisions;
+      const outcome = apply(provider, conflicts, choices);
+      actions.push(
+        resultAction(
+          "shortcuts.apply-decisions",
+          true,
+          unresolved.length > 0 ? "applied saved/shared decisions; unresolved conflicts were left unchanged" : "applied saved shortcut decisions",
+          [check.id],
+          {
+            provider: provider.id,
+            configCategory: outcome.configPath.split(/[\\/]/).pop() ?? "managed-shortcuts",
+            keybindingsChanged: outcome.keybindingsChanged,
+            reloadedLive: outcome.reloadedLive,
+            reloadHint: outcome.reloadHint,
+          },
+        ),
+      );
+    } else {
+      actions.push(
+        resultAction("shortcuts.apply-decisions", false, "no saved or shared shortcut changes were needed", [check.id], { provider: provider.id }),
+      );
+    }
+    if (unresolved.length > 0) {
+      actions.push(
+        blockedAction(
+          "shortcuts.needs-input",
+          "left unresolved shortcut conflicts unchanged",
+          [check.id],
+          { provider: provider.id, unresolved: unresolved.length, reason: "needs_input" },
+        ),
+      );
+    }
+    return actions;
+  } catch (error) {
+    return [failedAction("shortcuts.apply-decisions", [check.id], error, true)];
+  }
+}
+
+function validState(state: ServerState | null): state is ServerState {
+  return !!state &&
+    Number.isInteger(state.pid) && state.pid > 0 &&
+    Number.isInteger(state.injectorPid) && state.injectorPid > 0 &&
+    Number.isInteger(state.port) && state.port > 0 && state.port < 65536 &&
+    Number.isInteger(state.injectorPort) && state.injectorPort > 0 && state.injectorPort < 65536 &&
+    typeof state.version === "string";
+}
+
+async function verifyOwnedServer(
+  state: ServerState,
+  probe: ProcessProbe,
+  probePort: (port: number) => Promise<boolean>,
+  portOwner?: (port: number) => number | null,
+): Promise<boolean> {
+  if (portOwner) {
+    const owners = [portOwner(state.port), portOwner(state.injectorPort)];
+    if (owners.some((pid) => pid !== null && pid !== state.pid && pid !== state.injectorPid)) return false;
+  }
+  if (!probe.alive(state.pid) || !probe.alive(state.injectorPid)) return false;
+  if (!ownsServerProcess("code-server", state, probe.command(state.pid))) return false;
+  if (!ownsServerProcess("injector", state, probe.command(state.injectorPid))) return false;
+  const [upstream, injector] = await Promise.all([probePort(state.port), probePort(state.injectorPort)]);
+  return upstream && injector;
+}
+
+async function waitForOwnedServer(
+  state: ServerState,
+  probe: ProcessProbe,
+  probePort: (port: number) => Promise<boolean>,
+  portOwner: ((port: number) => number | null) | undefined,
+  timeoutMs: number,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  for (;;) {
+    if (await verifyOwnedServer(state, probe, probePort, portOwner)) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await sleep(Math.min(100, remaining));
+  }
+}
+
+async function repairDaemon(
+  check: DoctorCheck,
+  deps: RepairDependencies,
+): Promise<DoctorAction> {
+  const probe = deps.processProbe ?? systemProcessProbe;
+  const probePort = deps.probePort ?? answering;
+  const portOwner = deps.portOwner ?? probe.portOwner;
+  const readState = deps.readServerState ?? readServerState;
+  const removeState = deps.removeServerState ?? (() => fs.rmSync(STATE_FILE, { force: true }));
+  const start = deps.ensureServer ?? ensureServer;
+  const current = deps.currentServer ?? currentServer;
+  const sleep = deps.sleep ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  const startupTimeoutMs = deps.daemonStartupTimeoutMs ?? 30_000;
+  const stop = deps.stopServer ?? stopServer;
+  let state = readState();
+
+  try {
+    if (state && !validState(state)) {
+      return blockedAction("daemon.lifecycle", "daemon state is invalid and was left unchanged", [check.id], { reason: "invalid-state" });
+    }
+
+    if (state) {
+      const processes = [
+        { kind: "code-server" as const, pid: state.pid },
+        { kind: "injector" as const, pid: state.injectorPid },
+      ];
+      const liveUnowned = processes.filter(
+        ({ kind, pid }) => probe.alive(pid) && !ownsServerProcess(kind, state!, probe.command(pid)),
+      );
+      if (liveUnowned.length > 0) {
+        return blockedAction(
+          "daemon.lifecycle",
+          "refused to signal an unverified process",
+          [check.id],
+          { reason: "unverified-pid", pids: liveUnowned.map(({ pid }) => pid) },
+        );
+      }
+
+      const allDead = processes.every(({ pid }) => !probe.alive(pid));
+      if (allDead) {
+        removeState();
+        state = null;
+      } else {
+        const ownedState = state;
+        if (portOwner) {
+          const occupied = [ownedState.port, ownedState.injectorPort]
+            .map((port) => ({ port, pid: portOwner(port) }))
+            .filter(({ pid }) => pid !== null && pid !== ownedState.pid && pid !== ownedState.injectorPid);
+          if (occupied.length > 0) {
+            return blockedAction(
+              "daemon.lifecycle",
+              "refused to repair a daemon with an unattributed port owner",
+              [check.id],
+              { reason: "unattributed-port", occupiedPorts: occupied },
+            );
+          }
+        }
+        const healthy = await verifyOwnedServer(ownedState, probe, probePort, portOwner);
+        if (healthy) {
+          return resultAction("daemon.lifecycle", false, "owned daemon is already healthy", [check.id]);
+        }
+        stop();
+        state = null;
+      }
+    }
+
+    const started = await start();
+    const verified = await waitForOwnedServer(
+      started,
+      probe,
+      probePort,
+      portOwner,
+      startupTimeoutMs,
+      sleep,
+    );
+    if (!verified) {
+      const observed = await current().catch(() => null);
+      if (!observed || !(await waitForOwnedServer(observed, probe, probePort, portOwner, 1000, sleep))) {
+        throw new Error("started daemon did not pass ownership and localhost endpoint verification");
+      }
+    }
+    return resultAction(
+      "daemon.lifecycle",
+      true,
+      "started and verified the owned local daemon",
+      [check.id],
+      { ports: [started.port, started.injectorPort] },
+      true,
+    );
+  } catch (error) {
+    return failedAction("daemon.lifecycle", [check.id], error, true);
+  }
+}
+
+export async function repairChecks(
+  checks: DoctorCheck[],
+  context: DoctorContext,
+  deps: RepairDependencies = {},
+): Promise<DoctorAction[]> {
+  const actions: DoctorAction[] = [];
+  const managed = checkFor(checks, "paths.managedState");
+  if (shouldRepair(managed)) actions.push(await repairManagedState(context, managed!, deps));
+
+  const runtime = checkFor(checks, "runtime.terminalBrowser");
+  if (shouldRepair(runtime)) actions.push(await repairRuntime(runtime!, deps));
+
+  const codeServer = checkFor(checks, "runtime.codeServer");
+  if (shouldRepair(codeServer)) actions.push(await repairCodeServer(codeServer!, deps));
+
+  const profile = checkFor(checks, "profile.generatedState");
+  if (shouldRepair(profile)) actions.push(...(await repairProfile(profile!, deps)));
+
+  const shortcuts = checkFor(checks, "shortcuts.configuration");
+  if (shouldRepair(shortcuts) || shortcuts?.status === "needs_input") {
+    actions.push(...repairShortcuts(shortcuts!, deps));
+  }
+
+  const daemon = checkFor(checks, "daemon.state");
+  if (shouldRepair(daemon)) {
+    const prerequisiteFailure = actions.some(
+      (action) =>
+        action.status === "failed" &&
+        ["runtime.terminalBrowser.repair", "runtime.codeServer.repair", "profile.generatedState.repair"].includes(action.id),
+    );
+    if (prerequisiteFailure) {
+      actions.push({
+        id: "daemon.lifecycle",
+        status: "skipped",
+        reversible: true,
+        message: "daemon repair skipped because a prerequisite repair failed",
+        checkIds: [daemon!.id],
+        details: { reason: "dependency-failed" },
+      });
+    } else {
+      actions.push(await repairDaemon(daemon!, deps));
+    }
+  }
+  return actions;
+}

--- a/src/doctor/report.ts
+++ b/src/doctor/report.ts
@@ -1,0 +1,97 @@
+import type { DoctorContext } from "./context";
+import { summarize } from "./model";
+import type {
+  DoctorAction,
+  DoctorCheck,
+  DoctorExitCode,
+  DoctorReport,
+  DoctorSummary,
+} from "./model";
+
+export interface ReportCommand {
+  fix: boolean;
+  json: boolean;
+}
+
+export function environmentSummary(context: DoctorContext): DoctorReport["environment"] {
+  return {
+    platform: context.environment.platform,
+    architecture: context.environment.architecture,
+    tty: context.environment.tty.stdout,
+    terminalProvider: context.environment.terminalProvider?.id ?? null,
+  };
+}
+
+export function makeDoctorReport(input: {
+  command: ReportCommand;
+  context: DoctorContext;
+  startedAt: string;
+  durationMs: number;
+  checks: DoctorCheck[];
+  actions?: DoctorAction[];
+  exitCode?: DoctorExitCode;
+}): DoctorReport {
+  const actions = input.actions ?? [];
+  const base = summarize(input.checks, actions);
+  const summary: DoctorSummary = input.exitCode === undefined
+    ? base
+    : { ...base, exitCode: input.exitCode };
+  return {
+    schemaVersion: 1,
+    command: { fix: input.command.fix, json: input.command.json },
+    startedAt: input.startedAt,
+    durationMs: Math.max(0, Math.round(input.durationMs)),
+    environment: environmentSummary(input.context),
+    summary,
+    checks: input.checks,
+    actions,
+  };
+}
+
+export function makeUsageReport(
+  context: DoctorContext,
+  command: ReportCommand,
+  message: string,
+  startedAt = new Date().toISOString(),
+): DoctorReport {
+  const check: DoctorCheck = {
+    id: "command.usage",
+    status: "error",
+    severity: "error",
+    fixable: false,
+    message,
+  };
+  return makeDoctorReport({
+    command,
+    context,
+    startedAt,
+    durationMs: 0,
+    checks: [check],
+    exitCode: 64,
+  });
+}
+
+export function serializeDoctorJson(report: DoctorReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+function statusLabel(status: string): string {
+  return status.replace("_", " ");
+}
+
+export function renderDoctorText(report: DoctorReport): string {
+  const lines = [
+    `tode doctor: ${statusLabel(report.summary.status)} (exit ${report.summary.exitCode})`,
+    `checks: ${report.summary.ok} ok, ${report.summary.warnings} warning, ${report.summary.errors} error, ${report.summary.needsInput} needs input`,
+  ];
+  for (const check of report.checks) {
+    lines.push(`  [${statusLabel(check.status)}] ${check.id}: ${check.message}`);
+  }
+  if (report.actions.length > 0) {
+    lines.push("actions:");
+    for (const action of report.actions) {
+      lines.push(`  [${action.status}] ${action.id}: ${action.message}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { collectDoctorContext } from "./doctor/context";
+import { parseDoctorArgs } from "./doctor/command";
+import { runDoctor } from "./doctor/orchestrator";
+import { makeUsageReport, renderDoctorText, serializeDoctorJson } from "./doctor/report";
+
 import {
   CSS_FILE,
   codeServerBin,
@@ -105,6 +110,7 @@ function takeBool(args: string[], name: string): boolean {
 }
 
 const HELP = `Usage: tode [path...] [options]
+       tode doctor [--json] [--fix]
        tode --<command>
 
   tode                  Open the folder in the current working directory
@@ -129,6 +135,10 @@ Options:
   --ssh <user@host>     Run terminal-code on an ssh server
 
 Commands, each as the first argument:
+  doctor [--json] [--fix]
+                        Diagnose terminal-code; --json is parseable stdout,
+                        --fix may download verified runtimes, modify managed
+                        config, and start the owned local daemon
   --shortcut-setup      Resolve shortcut conflicts between terminal-code and the current terminal
   --timing              Profile terminal-code launch
   --import [editor]     Bring settings, keybindings, snippets and extensions
@@ -564,6 +574,23 @@ async function serveCommand(args: string[]): Promise<number> {
   return 0;
 }
 
+async function doctorCommand(args: string[]): Promise<number> {
+  const json = args.includes("--json");
+  const fix = args.includes("--fix");
+  const parsed = parseDoctorArgs(args);
+  if (parsed.kind === "usage-error") {
+    const report = makeUsageReport(collectDoctorContext(), { json, fix }, parsed.message);
+    if (json) process.stdout.write(serializeDoctorJson(report));
+    else process.stderr.write(renderDoctorText(report));
+    return 64;
+  }
+
+  const report = await runDoctor(parsed.options);
+  if (parsed.options.json) process.stdout.write(serializeDoctorJson(report));
+  else process.stdout.write(renderDoctorText(report));
+  return report.summary.exitCode;
+}
+
 async function main(): Promise<number> {
   const args = process.argv.slice(2);
   if (args[0] === "--version" || args[0] === "-v") {
@@ -581,6 +608,7 @@ async function main(): Promise<number> {
     process.stdout.write(HELP);
     return 0;
   }
+  if (args[0] === "doctor") return doctorCommand(args.slice(1));
   if (args[0] === "--shortcut-setup") {
     const rest = args.slice(1);
     const noBoot = takeBool(rest, "--no-boot");

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -224,7 +224,7 @@ export function registerThemeExtension(dir?: string): void {
     const parsed = JSON.parse(fs.readFileSync(manifest, "utf8"));
     if (Array.isArray(parsed)) listed = parsed;
   } catch {
-    return;
+    if (fs.existsSync(manifest)) return;
   }
   const folder = path.basename(themeDir);
   const entry: ExtensionEntry = {
@@ -235,7 +235,7 @@ export function registerThemeExtension(dir?: string): void {
     metadata: { isApplicationScoped: false, isMachineScoped: false, installedTimestamp: 0 },
   };
   const without = listed.filter((item) => item.identifier?.id !== entry.identifier.id);
-  fs.writeFileSync(manifest, `${JSON.stringify([...without, entry], null, 2)}\n`);
+  writeIfChanged(manifest, `${JSON.stringify([...without, entry], null, 2)}\n`);
 }
 
 const FONT_STACK = `"${FONT_FAMILY}", ${FONT_FALLBACKS}`;
@@ -346,6 +346,26 @@ export interface Binding {
 }
 
 const KEYBINDINGS_FILE = path.join(USER_DIR, "keybindings.json");
+
+export interface ManagedProfilePaths {
+  font: string;
+  css: string;
+  liveTheme: string;
+  settings: string;
+  keybindingsRecord: string;
+  extensionsRegistry: string;
+}
+
+export function managedProfilePaths(): ManagedProfilePaths {
+  return {
+    font: path.join(userFontsDir(), FONT_FILE),
+    css: CSS_FILE,
+    liveTheme: LIVE_THEME_FILE,
+    settings: path.join(USER_DIR, "settings.json"),
+    keybindingsRecord: KEYBINDINGS_RECORD,
+    extensionsRegistry: path.join(EXTENSIONS_DIR, "extensions.json"),
+  };
+}
 export const KEYBINDINGS_RECORD = path.join(DATA_DIR, "keybindings.tode.json");
 
 function sameBinding(a: Binding, b: Binding): boolean {
@@ -425,11 +445,15 @@ function writeBindings(mine: Binding[], theirs: Binding[]): boolean {
   const winners = [...overrideBindings(), ...claimBindings(), ...quitWinsBindings(theirs)];
   fs.mkdirSync(USER_DIR, { recursive: true });
   fs.mkdirSync(path.dirname(KEYBINDINGS_RECORD), { recursive: true });
-  fs.writeFileSync(KEYBINDINGS_RECORD, `${JSON.stringify([...mine, ...winners], null, 2)}\n`);
-  return writeIfChanged(
+  const recordChanged = writeIfChanged(
+    KEYBINDINGS_RECORD,
+    `${JSON.stringify([...mine, ...winners], null, 2)}\n`,
+  );
+  const userChanged = writeIfChanged(
     KEYBINDINGS_FILE,
     `// \n${JSON.stringify([...mine, ...theirs, ...winners], null, 2)}\n`,
   );
+  return recordChanged || userChanged;
 }
 
 export function mergeKeybindings(theirs: Binding[]): number {

--- a/src/runtime/release.ts
+++ b/src/runtime/release.ts
@@ -66,6 +66,25 @@ export async function lookup(version: string): Promise<Release> {
   };
 }
 
+export interface RuntimeInspection {
+  source: Source | "missing" | "invalid";
+  version: string | null;
+  root: string;
+  binary: string | null;
+  valid: boolean;
+  reason?: string;
+}
+
+export interface RuntimeInspectionOptions {
+  version?: string;
+  override?: string | null;
+  vendoredRoot?: string;
+  pinnedRoot?: string;
+  systemRoot?: string;
+  exists?: (file: string) => boolean;
+  readVersion?: (root: string) => string | null;
+}
+
 function versionAt(root: string): string | null {
   try {
     return fs.readFileSync(path.join(root, "VERSION"), "utf8").trim() || null;
@@ -82,13 +101,76 @@ export function electronEntry(root: string): string {
     : path.join(root, "electron", "electron");
 }
 
-function usable(root: string, version: string): boolean {
+function runtimeUsable(
+  root: string,
+  version: string,
+  exists: (file: string) => boolean,
+  readVersion: (root: string) => string | null,
+): boolean {
   return (
-    versionAt(root) === version &&
-    fs.existsSync(path.join(root, "cli", "dist", "main.js")) &&
-    fs.existsSync(electronEntry(root))
+    readVersion(root) === version &&
+    exists(path.join(root, "cli", "dist", "main.js")) &&
+    exists(electronEntry(root))
   );
 }
+
+export function inspectRuntime(options: RuntimeInspectionOptions = {}): RuntimeInspection {
+  const version = options.version ?? PINNED_VERSION;
+  const exists = options.exists ?? fs.existsSync;
+  const readVersion = options.readVersion ?? versionAt;
+  const override = options.override === undefined ? process.env.TODE_TERMINAL_BROWSER_BIN ?? null : options.override;
+  const vendoredRoot = options.vendoredRoot ?? VENDORED;
+  const pinnedRoot = options.pinnedRoot ?? rootFor(version);
+  const systemRoot = options.systemRoot ?? SYSTEM_INSTALL;
+
+  if (override) {
+    const root = path.resolve(path.dirname(override), "..");
+    const valid = exists(override);
+    return {
+      source: valid ? "override" : "invalid",
+      version: valid ? readVersion(root) ?? "override" : null,
+      root,
+      binary: override,
+      valid,
+      ...(valid ? {} : { reason: "TODE_TERMINAL_BROWSER_BIN does not exist" }),
+    };
+  }
+
+  const candidates: { source: Source; root: string }[] = [
+    ...(version === PINNED_VERSION ? [{ source: "vendored" as const, root: vendoredRoot }] : []),
+    { source: "pinned", root: pinnedRoot },
+    { source: "cloned", root: systemRoot },
+  ];
+  let invalidRoot: string | null = null;
+
+  for (const candidate of candidates) {
+    if (runtimeUsable(candidate.root, version, exists, readVersion)) {
+      return {
+        source: candidate.source,
+        version,
+        root: candidate.root,
+        binary: path.join(candidate.root, "bin", "terminal-browser"),
+        valid: true,
+      };
+    }
+    if (readVersion(candidate.root) !== null) invalidRoot ??= candidate.root;
+  }
+
+  const root = invalidRoot ?? pinnedRoot;
+  return {
+    source: invalidRoot ? "invalid" : "missing",
+    version: readVersion(root),
+    root,
+    binary: path.join(root, "bin", "terminal-browser"),
+    valid: false,
+    reason: invalidRoot ? "runtime is missing a required executable" : "runtime is not installed",
+  };
+}
+
+function usable(root: string, version: string): boolean {
+  return runtimeUsable(root, version, fs.existsSync, versionAt);
+}
+
 
 function rootFor(version: string): string {
   return path.join(RUNTIME_DIR, "terminal-browser", version);

--- a/src/shortcuts/wizard.ts
+++ b/src/shortcuts/wizard.ts
@@ -40,7 +40,11 @@ export function normalizeChord(input: string): string | null {
   return [...MODS.filter((mod) => mods.includes(mod)), key].join("+");
 }
 
-function applyDecisions(provider: ShortcutProvider, conflicts: ProviderConflict[], choices: Record<string, Decision>): void {
+function applyDecisions(
+  provider: ShortcutProvider,
+  conflicts: ProviderConflict[],
+  choices: Record<string, Decision>,
+): { configPath: string; keybindingsChanged: boolean } {
   const moves = conflicts
     .filter((conflict) => choices[conflict.editorId]?.choice === "terminal")
     .map((conflict) => {
@@ -55,9 +59,23 @@ function applyDecisions(provider: ShortcutProvider, conflicts: ProviderConflict[
     const chord = named === -1 ? rest : rest.slice(0, named);
     moves.push({ trigger: provider.trigger(chord), to: decision.key, action: decision.action });
   }
-  provider.apply(moves);
+  const configPath = provider.apply(moves);
   saveDecisions({ version: 1, terminal: provider.id, choices });
-  installKeybindings();
+  const keybindingsChanged = installKeybindings();
+  return { configPath, keybindingsChanged };
+}
+
+export function applyRecordedDecisions(
+  provider: ShortcutProvider,
+  conflicts: ProviderConflict[],
+  choices: Record<string, Decision>,
+): { configPath: string; keybindingsChanged: boolean; reloadedLive: boolean; reloadHint: string } {
+  const applied = applyDecisions(provider, conflicts, choices);
+  return {
+    ...applied,
+    reloadedLive: provider.onApplied(),
+    reloadHint: provider.reloadHint(),
+  };
 }
 
 function say(text: string, style: (line: string) => string = (line) => line): void {

--- a/test/doctor-checks.test.js
+++ b/test/doctor-checks.test.js
@@ -1,0 +1,41 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { collectDoctorContext } = require("../dist/doctor/context.js");
+const { collectReadOnlyChecks, checkManagedState } = require("../dist/doctor/checks.js");
+
+test("reports supported terminal and TTY as healthy", () => {
+  const context = collectDoctorContext({
+    env: { ...process.env, TERM_PROGRAM: "ghostty" },
+    tty: { stdin: true, stdout: true, stderr: true },
+    exists: () => true,
+  });
+
+  const checks = collectReadOnlyChecks(context);
+  assert.equal(checks.find((check) => check.id === "environment.platform").status, "ok");
+  assert.equal(checks.find((check) => check.id === "environment.tty").status, "ok");
+  assert.equal(checks.find((check) => check.id === "environment.terminal").status, "ok");
+  assert.equal(checks.find((check) => check.id === "paths.managedState").status, "ok");
+});
+
+test("reports non-TTY and unknown terminal as warnings", () => {
+  const context = collectDoctorContext({
+    env: { ...process.env, TERM_PROGRAM: "unknown", TERM: "dumb" },
+    tty: { stdin: false, stdout: false, stderr: false },
+    exists: () => true,
+  });
+
+  const checks = collectReadOnlyChecks(context);
+  assert.equal(checks.find((check) => check.id === "environment.tty").status, "warning");
+  assert.equal(checks.find((check) => check.id === "environment.terminal").status, "warning");
+});
+
+test("missing managed directories are fixable and remain read-only", () => {
+  const context = collectDoctorContext({ exists: () => false });
+  const result = checkManagedState(context);
+
+  assert.equal(result.id, "paths.managedState");
+  assert.equal(result.status, "warning");
+  assert.equal(result.fixable, true);
+  assert.deepEqual(result.details.missing, ["data", "state", "cache", "runtime", "logs"]);
+});

--- a/test/doctor-cli.test.js
+++ b/test/doctor-cli.test.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { test } = require("node:test");
+
+const root = path.resolve(__dirname, "..");
+const entry = path.join(root, "dist", "main.js");
+
+function isolatedEnv() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tode-doctor-cli-"));
+  const env = { ...process.env };
+  env.HOME = home;
+  env.XDG_DATA_HOME = path.join(home, "data");
+  env.XDG_STATE_HOME = path.join(home, "state");
+  env.XDG_CACHE_HOME = path.join(home, "cache");
+  delete env.TODE_CODE_SERVER;
+  delete env.TODE_TERMINAL_BROWSER_BIN;
+  delete env.TERM_PROGRAM;
+  delete env.GHOSTTY_RESOURCES_DIR;
+  delete env.TERM;
+  delete env.KITTY_WINDOW_ID;
+  delete env.KITTY_PID;
+  return env;
+}
+
+test("built doctor JSON is one parseable stdout document", () => {
+  const result = spawnSync(process.execPath, [entry, "doctor", "--json"], {
+    cwd: root,
+    env: isolatedEnv(),
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 64);
+  assert.equal(result.stderr, "");
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.schemaVersion, 1);
+  assert.deepEqual(report.command, { fix: false, json: true });
+  assert.ok(Array.isArray(report.checks));
+  assert.ok(Array.isArray(report.actions));
+});
+
+test("invalid doctor JSON options return a JSON usage report with exit 64", () => {
+  const result = spawnSync(process.execPath, [entry, "doctor", "--json", "--unknown"], {
+    cwd: root,
+    env: isolatedEnv(),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 64);
+  assert.equal(result.stderr, "");
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.summary.exitCode, 64);
+  assert.equal(report.checks[0].id, "command.usage");
+});

--- a/test/doctor-command.test.js
+++ b/test/doctor-command.test.js
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { parseDoctorArgs } = require("../dist/doctor/command.js");
+
+test("parses no doctor flags as check-only text mode", () => {
+  assert.deepEqual(parseDoctorArgs([]), { kind: "ok", options: { json: false, fix: false } });
+});
+
+test("parses json and fix flags in either order", () => {
+  assert.deepEqual(parseDoctorArgs(["--json", "--fix"]), {
+    kind: "ok",
+    options: { json: true, fix: true },
+  });
+  assert.deepEqual(parseDoctorArgs(["--fix", "--json"]), {
+    kind: "ok",
+    options: { json: true, fix: true },
+  });
+});
+
+test("rejects unknown options and positional arguments", () => {
+  assert.deepEqual(parseDoctorArgs(["--verbose"]), {
+    kind: "usage-error",
+    message: "unknown doctor option --verbose",
+  });
+  assert.deepEqual(parseDoctorArgs(["path"]), {
+    kind: "usage-error",
+    message: "unknown doctor option path",
+  });
+});
+
+test("does not mutate the input array", () => {
+  const args = ["--json", "--fix"];
+  const before = [...args];
+  parseDoctorArgs(args);
+  assert.deepEqual(args, before);
+});

--- a/test/doctor-context.test.js
+++ b/test/doctor-context.test.js
@@ -1,0 +1,35 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { collectDoctorContext } = require("../dist/doctor/context.js");
+
+test("collects platform, runtime, terminal and managed paths without writing", () => {
+  const seen = [];
+  const context = collectDoctorContext({
+    env: { ...process.env, TERM_PROGRAM: "ghostty" },
+    tty: { stdin: true, stdout: true, stderr: true },
+    codeServerBinary: "/fixture/code-server",
+    exists: (file) => {
+      seen.push(file);
+      return false;
+    },
+  });
+
+  assert.equal(context.environment.terminalProvider.id, "ghostty");
+  assert.equal(context.environment.tty.stdout, true);
+  assert.equal(context.runtime.codeServerBinary, "/fixture/code-server");
+  assert.ok(context.runtime.terminalBrowserVersion);
+  assert.ok(context.paths.data);
+  assert.deepEqual(seen, []);
+});
+
+test("unsupported environment does not fabricate a provider", () => {
+  const context = collectDoctorContext({
+    env: { ...process.env, TERM_PROGRAM: "unknown", TERM: "dumb" },
+    tty: { stdin: false, stdout: false, stderr: false },
+    exists: () => false,
+  });
+
+  assert.equal(context.environment.terminalProvider, null);
+  assert.equal(context.environment.tty.stdout, false);
+});

--- a/test/doctor-daemon.test.js
+++ b/test/doctor-daemon.test.js
@@ -1,0 +1,80 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { checkDaemon } = require("../dist/doctor/checks.js");
+
+const state = {
+  pid: 101,
+  port: 9001,
+  injectorPid: 102,
+  injectorPort: 9002,
+  version: "4.132.0",
+  startedAt: 1,
+};
+
+const probes = (overrides = {}) => ({
+  alive: () => true,
+  command: (pid) =>
+    pid === state.pid
+      ? "code-server --auth none --bind-addr 127.0.0.1:9001 --app-name tode"
+      : "node injector-main.js 9001 9002",
+  probePort: async () => true,
+  ...overrides,
+});
+
+test("reports a healthy owned daemon", async () => {
+  const result = await checkDaemon({ state, ...probes() });
+  assert.equal(result.status, "ok");
+  assert.equal(result.fixable, true);
+});
+
+test("reports absent daemon as repairable", async () => {
+  const result = await checkDaemon({ state: null });
+  assert.equal(result.status, "warning");
+  assert.equal(result.fixable, true);
+});
+
+test("reports dead recorded processes as repairable stale state", async () => {
+  const result = await checkDaemon({
+    state,
+    ...probes({ alive: (pid) => pid !== state.injectorPid }),
+  });
+  assert.equal(result.status, "warning");
+  assert.deepEqual(result.details.deadPids, [state.injectorPid]);
+});
+
+test("blocks a live but unverified process", async () => {
+  const result = await checkDaemon({
+    state,
+    ...probes({ command: () => "unrelated-process --bind-addr 127.0.0.1:9001" }),
+  });
+  assert.equal(result.status, "error");
+  assert.equal(result.fixable, false);
+  assert.deepEqual(result.details.unownedPids, [state.pid, state.injectorPid]);
+});
+
+test("reports an unresponsive owned endpoint", async () => {
+  const result = await checkDaemon({
+    state,
+    ...probes({ probePort: async (port) => port === state.port }),
+  });
+  assert.equal(result.status, "error");
+  assert.equal(result.fixable, true);
+  assert.deepEqual(result.details, { upstream: true, injector: false });
+});
+
+test("blocks an unattributed process occupying a daemon port", async () => {
+  const result = await checkDaemon({
+    state,
+    ...probes({ portOwner: (port) => (port === state.injectorPort ? 999 : port === state.port ? state.pid : null) }),
+  });
+  assert.equal(result.status, "error");
+  assert.equal(result.fixable, false);
+  assert.deepEqual(result.details.occupiedPorts, [{ port: state.injectorPort, pid: 999 }]);
+});
+
+test("reports malformed daemon state as a non-fixable error", async () => {
+  const result = await checkDaemon({ state: { pid: 0 } });
+  assert.equal(result.status, "error");
+  assert.equal(result.fixable, false);
+});

--- a/test/doctor-model.test.js
+++ b/test/doctor-model.test.js
@@ -1,0 +1,78 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { summarize } = require("../dist/doctor/model.js");
+
+const check = (status, id = status) => ({
+  id,
+  status,
+  severity: status === "error" ? "error" : "warning",
+  fixable: status !== "needs_input",
+  message: id,
+});
+
+const action = (status, id = status) => ({
+  id,
+  status,
+  reversible: true,
+  message: id,
+  checkIds: [id],
+});
+
+test("summarize counts check and action outcomes", () => {
+  assert.deepEqual(
+    summarize(
+      [check("ok"), check("warning"), check("needs_input"), check("skipped")],
+      [action("changed"), action("blocked"), action("failed")],
+    ),
+    {
+      status: "error",
+      checks: 4,
+      ok: 1,
+      warnings: 1,
+      errors: 0,
+      needsInput: 1,
+      changed: 1,
+      blocked: 1,
+      failed: 1,
+      exitCode: 1,
+    },
+  );
+});
+
+test("needs_input maps to exit code 2 when no error exists", () => {
+  assert.equal(summarize([check("needs_input")], []).exitCode, 2);
+  assert.equal(summarize([check("needs_input")], []).status, "needs_input");
+});
+
+test("warning does not fail a healthy report", () => {
+  const result = summarize([check("ok"), check("warning")], [action("unchanged")]);
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.status, "warning");
+});
+
+test("error and failed action take precedence over needs_input", () => {
+  assert.equal(summarize([check("error"), check("needs_input")], []).exitCode, 1);
+  assert.equal(summarize([check("needs_input")], [action("failed")]).exitCode, 1);
+});
+
+test("empty checks are healthy", () => {
+  assert.deepEqual(summarize([], []), {
+    status: "ok",
+    checks: 0,
+    ok: 0,
+    warnings: 0,
+    errors: 0,
+    needsInput: 0,
+    changed: 0,
+    blocked: 0,
+    failed: 0,
+    exitCode: 0,
+  });
+});
+
+test("blocked needs_input action maps to exit code 2", () => {
+  const result = summarize([], [{ ...action("blocked"), details: { reason: "needs_input" } }]);
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.status, "needs_input");
+});

--- a/test/doctor-profile.test.js
+++ b/test/doctor-profile.test.js
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { collectDoctorContext } = require("../dist/doctor/context.js");
+const { checkGeneratedProfile } = require("../dist/doctor/checks.js");
+
+test("reports all generated profile artifacts when they are missing", () => {
+  const result = checkGeneratedProfile(collectDoctorContext({ exists: () => false }));
+
+  assert.equal(result.id, "profile.generatedState");
+  assert.equal(result.status, "warning");
+  assert.equal(result.fixable, true);
+  assert.deepEqual(result.details.missing, [
+    "font",
+    "css",
+    "liveTheme",
+    "settings",
+    "keybindingsRecord",
+    "extensionsRegistry",
+    "bridgeManifest",
+    "bridgeSource",
+  ]);
+});
+
+test("reports generated profile as healthy without inspecting user file contents", () => {
+  const checked = [];
+  const result = checkGeneratedProfile(
+    collectDoctorContext({
+      exists: (file) => {
+        checked.push(file);
+        return true;
+      },
+    }),
+  );
+
+  assert.equal(result.status, "ok");
+  assert.deepEqual(result.details, undefined);
+  assert.ok(checked.length > 0);
+});

--- a/test/doctor-repairs.test.js
+++ b/test/doctor-repairs.test.js
@@ -1,0 +1,179 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { repairChecks } = require("../dist/doctor/repairs.js");
+
+const baseContext = {
+  environment: {
+    platform: "darwin",
+    architecture: "arm64",
+    targetTriple: "darwin-arm64",
+    tty: { stdin: false, stdout: false, stderr: false },
+    terminalProvider: null,
+  },
+  paths: {
+    install: "/install",
+    vendor: "/install/vendor",
+    data: "/managed/data",
+    state: "/managed/state",
+    cache: "/managed/cache",
+    runtime: "/managed/runtime",
+    logs: "/managed/logs",
+    codeServer: "/managed/code-server",
+    browser: { data: "/managed/browser-data", state: "/managed/browser-state", cache: "/managed/browser-cache", appData: "/managed/browser-app" },
+  },
+  runtime: {
+    terminalBrowserVersion: "v0.5.8",
+    terminalBrowserOverride: null,
+    codeServerVersion: "4.132.0",
+    codeServerOverride: null,
+    codeServerBinary: null,
+  },
+  exists: () => false,
+};
+
+const check = (id, status = "warning", fixable = true) => ({
+  id,
+  status,
+  severity: status === "error" ? "error" : status === "needs_input" || status === "warning" ? "warning" : "info",
+  fixable,
+  message: status,
+});
+
+test("managed state repair creates only terminal-code directories", async () => {
+  const made = [];
+  const actions = await repairChecks(
+    [check("paths.managedState")],
+    baseContext,
+    { mkdir: (directory) => made.push(directory) },
+  );
+  assert.deepEqual(made, ["/managed/data", "/managed/state", "/managed/cache", "/managed/runtime", "/managed/logs"]);
+  assert.equal(actions[0].id, "paths.create-managed-directories");
+  assert.equal(actions[0].status, "changed");
+});
+
+test("runtime repairs use injected verified provisioning paths", async () => {
+  let runtimeCalls = 0;
+  let codeServerCalls = 0;
+  const actions = await repairChecks(
+    [check("runtime.terminalBrowser", "error"), check("runtime.codeServer", "error")],
+    baseContext,
+    {
+      resolveRuntime: async () => { runtimeCalls += 1; },
+      ensureCodeServer: async () => { codeServerCalls += 1; return "/managed/code-server/bin/code-server"; },
+    },
+  );
+  assert.equal(runtimeCalls, 1);
+  assert.equal(codeServerCalls, 1);
+  assert.deepEqual(actions.map((action) => action.status), ["changed", "changed"]);
+});
+
+test("unresolved shortcuts are blocked without provider mutation", async () => {
+  let applied = false;
+  const provider = {
+    id: "ghostty",
+    name: "Ghostty",
+    detect: () => true,
+    ready: () => null,
+    scan: () => [{
+      editorId: "ctrl+x",
+      trigger: "ctrl+x",
+      current: "close_window",
+      editor: { means: "close", command: "workbench.action.closeWindow" },
+      others: [],
+      inTerminal: "closes",
+      short: "close",
+      freed: "close",
+      tradeoff: "close",
+    }],
+    takenAs: () => "close_window",
+    trigger: (chord) => chord,
+    describe: (action) => action,
+    apply: () => { applied = true; return "/managed/keybinds"; },
+    onApplied: () => false,
+    undo: () => false,
+    reloadHint: () => "reload",
+  };
+  const actions = await repairChecks(
+    [check("shortcuts.configuration", "needs_input", false)],
+    baseContext,
+    { provider },
+  );
+  assert.equal(applied, false);
+  assert.equal(actions.some((action) => action.status === "blocked"), true);
+  assert.equal(actions.find((action) => action.id === "shortcuts.needs-input").details.reason, "needs_input");
+});
+
+test("daemon repair never signals a live unverified PID", async () => {
+  let stopped = false;
+  let started = false;
+  const state = { pid: 31, port: 9011, injectorPid: 32, injectorPort: 9012, version: "4.132.0", startedAt: 1 };
+  const actions = await repairChecks(
+    [check("daemon.state", "error")],
+    baseContext,
+    {
+      readServerState: () => state,
+      processProbe: {
+        alive: () => true,
+        command: () => "unrelated-process",
+      },
+      stopServer: () => { stopped = true; return true; },
+      ensureServer: async () => { started = true; return state; },
+    },
+  );
+  assert.equal(stopped, false);
+  assert.equal(started, false);
+  assert.equal(actions[0].status, "blocked");
+  assert.equal(actions[0].details.reason, "unverified-pid");
+});
+
+test("profile repair records changed and unchanged generated artifacts", async () => {
+  const calls = [];
+  const palette = { background: [0, 0, 0], foreground: [255, 255, 255], ansi: Array.from({ length: 16 }, () => [0, 0, 0]) };
+  const actions = await repairChecks(
+    [check("profile.generatedState")],
+    baseContext,
+    {
+      readPalette: async () => ({ palette, source: "default" }),
+      ensureFont: () => "present",
+      installTheme: () => ({ changed: false, fingerprint: "abc" }),
+      installCss: () => { calls.push("css"); return true; },
+      setLiveTheme: () => { calls.push("theme"); return false; },
+      installSettings: () => false,
+      installKeybindings: () => true,
+      installBridge: () => true,
+      todeCommand: () => ["tode"],
+    },
+  );
+  assert.equal(calls.length, 2);
+  assert.equal(actions.find((action) => action.id === "profile.css").status, "changed");
+  assert.equal(actions.find((action) => action.id === "profile.live-theme").status, "unchanged");
+  assert.equal(actions.find((action) => action.id === "profile.font").status, "unchanged");
+});
+
+test("stale state with one dead owned PID is cleaned and restarted", async () => {
+  let stopped = false;
+  let started = false;
+  const stale = { pid: 31, port: 9011, injectorPid: 32, injectorPort: 9012, version: "4.132.0", startedAt: 1 };
+  const fresh = { pid: 41, port: 9021, injectorPid: 42, injectorPort: 9022, version: "4.132.0", startedAt: 2 };
+  const alive = (pid) => pid === stale.injectorPid || pid === fresh.pid || pid === fresh.injectorPid;
+  const command = (pid) => pid === stale.injectorPid
+    ? "node injector-main.js 9011 9012"
+    : pid === fresh.pid
+      ? "code-server --bind-addr 127.0.0.1:9021 --app-name tode"
+      : "node injector-main.js 9021 9022";
+  const actions = await repairChecks(
+    [check("daemon.state", "warning")],
+    baseContext,
+    {
+      readServerState: () => stale,
+      processProbe: { alive, command },
+      probePort: async () => true,
+      stopServer: () => { stopped = true; return true; },
+      ensureServer: async () => { started = true; return fresh; },
+    },
+  );
+  assert.equal(stopped, true);
+  assert.equal(started, true);
+  assert.equal(actions[0].status, "changed");
+});

--- a/test/doctor-report.test.js
+++ b/test/doctor-report.test.js
@@ -1,0 +1,115 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { runDoctor } = require("../dist/doctor/orchestrator.js");
+const { serializeDoctorJson } = require("../dist/doctor/report.js");
+
+const context = {
+  environment: {
+    platform: "darwin",
+    architecture: "arm64",
+    targetTriple: "darwin-arm64",
+    tty: { stdin: false, stdout: false, stderr: false },
+    terminalProvider: null,
+  },
+  paths: {
+    install: "/managed/install",
+    vendor: "/managed/vendor",
+    data: "/managed/data",
+    state: "/managed/state",
+    cache: "/managed/cache",
+    runtime: "/managed/runtime",
+    logs: "/managed/logs",
+    codeServer: "/managed/code-server",
+    browser: { data: "/managed/browser-data", state: "/managed/browser-state", cache: "/managed/browser-cache", appData: "/managed/browser-app" },
+  },
+  runtime: {
+    terminalBrowserVersion: "v0.5.8",
+    terminalBrowserOverride: null,
+    codeServerVersion: "4.132.0",
+    codeServerOverride: null,
+    codeServerBinary: null,
+  },
+  exists: () => true,
+};
+
+const check = (status, id = "example.check") => ({
+  id,
+  status,
+  severity: status === "error" ? "error" : status === "warning" || status === "needs_input" ? "warning" : "info",
+  fixable: status !== "ok",
+  message: status,
+});
+
+test("check-only runs the registry once and emits one JSON document", async () => {
+  let collections = 0;
+  const report = await runDoctor(
+    { json: true, fix: false },
+    {
+      context,
+      now: () => 1000,
+      collectChecks: async () => {
+        collections += 1;
+        return [check("ok")];
+      },
+    },
+  );
+  assert.equal(collections, 1);
+  assert.equal(report.summary.exitCode, 0);
+  const encoded = serializeDoctorJson(report);
+  assert.equal(encoded.split("\n").filter(Boolean).length > 1, true);
+  assert.deepEqual(JSON.parse(encoded), report);
+});
+
+test("fix runs initial checks, repairs, and final checks", async () => {
+  let collections = 0;
+  let repaired = false;
+  const report = await runDoctor(
+    { json: true, fix: true },
+    {
+      context,
+      now: () => 2000,
+      collectChecks: async () => {
+        collections += 1;
+        return [check(repaired ? "ok" : "warning")];
+      },
+      repairChecks: async () => {
+        repaired = true;
+        return [{ id: "example.repair", status: "changed", reversible: true, message: "changed", checkIds: ["example.check"] }];
+      },
+    },
+  );
+  assert.equal(collections, 2);
+  assert.equal(report.summary.status, "ok");
+  assert.equal(report.summary.changed, 1);
+  assert.equal(report.summary.exitCode, 0);
+});
+
+test("collector exceptions become a report error", async () => {
+  const report = await runDoctor(
+    { json: true, fix: false },
+    { context, collectChecks: async () => { throw new Error("read failed"); } },
+  );
+  assert.equal(report.checks[0].id, "doctor.checks");
+  assert.equal(report.summary.exitCode, 1);
+});
+
+test("needs_input remains exit code 2 without a failed action", async () => {
+  const report = await runDoctor(
+    { json: true, fix: true },
+    {
+      context,
+      collectChecks: async () => [check("needs_input", "shortcuts.configuration")],
+      repairChecks: async () => [{
+        id: "shortcuts.needs-input",
+        status: "blocked",
+        reversible: true,
+        message: "left unchanged",
+        checkIds: ["shortcuts.configuration"],
+      }],
+    },
+  );
+  assert.equal(report.summary.exitCode, 2);
+  assert.equal(report.summary.blocked, 1);
+  assert.equal(report.summary.failed, 0);
+});

--- a/test/doctor-runtime.test.js
+++ b/test/doctor-runtime.test.js
@@ -1,0 +1,105 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const path = require("node:path");
+
+const {
+  PINNED_VERSION,
+  electronEntry,
+  inspectRuntime,
+} = require("../dist/runtime/release.js");
+const {
+  CODE_SERVER_VERSION,
+  inspectCodeServer,
+} = require("../dist/codeserver/vendored.js");
+
+function runtimeFixture(root, version = PINNED_VERSION) {
+  const files = new Set([
+    path.join(root, "VERSION"),
+    path.join(root, "cli", "dist", "main.js"),
+    electronEntry(root),
+  ]);
+  return {
+    exists: (file) => files.has(file),
+    readVersion: (candidate) => candidate === root ? version : null,
+  };
+}
+
+test("inspects a valid vendored runtime without creating a launcher", () => {
+  const root = "/fixture/vendored";
+  const result = inspectRuntime({
+    vendoredRoot: root,
+    pinnedRoot: "/fixture/pinned",
+    systemRoot: "/fixture/system",
+    ...runtimeFixture(root),
+  });
+
+  assert.deepEqual(result, {
+    source: "vendored",
+    version: PINNED_VERSION,
+    root,
+    binary: path.join(root, "bin", "terminal-browser"),
+    valid: true,
+  });
+});
+
+test("distinguishes missing and invalid runtime trees", () => {
+  const missing = inspectRuntime({
+    vendoredRoot: "/fixture/vendored",
+    pinnedRoot: "/fixture/pinned",
+    systemRoot: "/fixture/system",
+    exists: () => false,
+    readVersion: () => null,
+  });
+  assert.equal(missing.source, "missing");
+  assert.equal(missing.valid, false);
+
+  const invalid = inspectRuntime({
+    vendoredRoot: "/fixture/vendored",
+    pinnedRoot: "/fixture/pinned",
+    systemRoot: "/fixture/system",
+    exists: (file) => file.endsWith("/VERSION"),
+    readVersion: (root) => root === "/fixture/vendored" ? PINNED_VERSION : null,
+  });
+  assert.equal(invalid.source, "invalid");
+  assert.equal(invalid.reason, "runtime is missing a required executable");
+});
+
+test("inspects an explicit runtime override without probing release endpoints", () => {
+  const result = inspectRuntime({
+    override: "/fixture/runtime/bin/terminal-browser",
+    exists: (file) => file === "/fixture/runtime/bin/terminal-browser",
+    readVersion: (root) => root === "/fixture/runtime" ? "dev" : null,
+  });
+
+  assert.equal(result.source, "override");
+  assert.equal(result.valid, true);
+  assert.equal(result.version, "dev");
+});
+
+test("inspects pinned code-server binary without provisioning", () => {
+  const root = "/fixture/code-server";
+  const binary = path.join(root, "bin", "code-server");
+  const result = inspectCodeServer({
+    root,
+    exists: (file) => file === binary,
+  });
+
+  assert.deepEqual(result, {
+    source: "pinned",
+    version: CODE_SERVER_VERSION,
+    root,
+    binary,
+    valid: true,
+  });
+});
+
+test("reports missing configured code-server override", () => {
+  const result = inspectCodeServer({
+    override: "/fixture/missing-code-server",
+    exists: () => false,
+  });
+
+  assert.equal(result.source, "invalid");
+  assert.equal(result.valid, false);
+  assert.equal(result.reason, "code-server binary is not present");
+});

--- a/test/doctor-shortcuts.test.js
+++ b/test/doctor-shortcuts.test.js
@@ -1,0 +1,98 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { collectDoctorContext } = require("../dist/doctor/context.js");
+const { checkShortcuts } = require("../dist/doctor/checks.js");
+
+const context = collectDoctorContext({
+  env: { ...process.env, TERM_PROGRAM: "ghostty" },
+  tty: { stdin: true, stdout: true, stderr: true },
+  exists: () => true,
+});
+
+const provider = (overrides = {}) => ({
+  id: "fake",
+  name: "Fake Terminal",
+  detect: () => true,
+  ready: () => null,
+  scan: () => [],
+  takenAs: () => null,
+  trigger: (chord) => chord,
+  describe: (action) => action,
+  apply: () => {
+    throw new Error("mutation must not run during check");
+  },
+  onApplied: () => {
+    throw new Error("reload must not run during check");
+  },
+  undo: () => {
+    throw new Error("undo must not run during check");
+  },
+  reloadHint: () => "reload",
+  ...overrides,
+});
+
+test("unsupported provider is reported without a repair action", () => {
+  const result = checkShortcuts(context, { provider: null, decisions: null });
+  assert.equal(result.status, "warning");
+  assert.equal(result.fixable, false);
+});
+
+test("provider readiness failure is reported without scanning or mutating", () => {
+  let scanned = false;
+  const result = checkShortcuts(context, {
+    provider: provider({
+      ready: () => "terminal config is not ready",
+      scan: () => {
+        scanned = true;
+        return [];
+      },
+    }),
+    decisions: null,
+  });
+  assert.equal(result.status, "warning");
+  assert.equal(result.message, "terminal config is not ready");
+  assert.equal(scanned, false);
+});
+
+test("unresolved conflicts require user input", () => {
+  const result = checkShortcuts(context, {
+    provider: provider({
+      scan: () => [{ editorId: "cmd+x", shared: undefined }],
+    }),
+    decisions: null,
+  });
+  assert.equal(result.status, "needs_input");
+  assert.equal(result.fixable, false);
+  assert.deepEqual(result.actionIds, ["shortcuts.apply-decisions"]);
+  assert.equal(result.details.unresolved, 1);
+});
+
+test("saved decisions and shared conflicts are repairable", () => {
+  const conflicts = [
+    { editorId: "cmd+x" },
+    { editorId: "cmd+y", shared: { action: "copy", note: "shared" } },
+  ];
+  const result = checkShortcuts(context, {
+    provider: provider({ scan: () => conflicts }),
+    decisions: {
+      version: 1,
+      terminal: "fake",
+      choices: { "cmd+x": { choice: "terminal" } },
+    },
+  });
+  assert.equal(result.status, "warning");
+  assert.equal(result.fixable, true);
+  assert.equal(result.details.conflicts, 2);
+  assert.deepEqual(result.actionIds, ["shortcuts.apply-decisions"]);
+});
+
+test("provider scan errors are captured as check errors", () => {
+  const result = checkShortcuts(context, {
+    provider: provider({ scan: () => { throw new Error("cannot inspect terminal"); } }),
+    decisions: null,
+  });
+  assert.equal(result.status, "error");
+  assert.equal(result.fixable, false);
+  assert.equal(result.message, "cannot inspect terminal");
+});


### PR DESCRIPTION
## Problem / Motivation
Terminal-code currently discovers and repairs runtime, profile, shortcut, and daemon state opportunistically during normal launch. When one component is missing or unhealthy, users and agents receive a narrow operational error instead of a complete, machine-readable diagnosis. There is no safe, deterministic way to inspect the installation or repair terminal-code-managed state without invoking the normal launch flow.

## Why it matters
Environment-specific failures are difficult to reproduce and difficult for CI or AI agents to triage from prose. A diagnostic command gives users an actionable report, makes repair outcomes observable, and prevents unsafe guesses around shortcut ownership or unrelated processes.

## What changed
This PR adds `tode doctor [--json] [--fix]` using a check/repair plan engine:

- adds stable report, check, action, summary, and exit-code contracts;
- adds parseable JSON output with diagnostics on stderr and one JSON document on stdout;
- adds read-only checks for platform/TTY, terminal provider, managed paths, runtime, code-server, generated profile, shortcuts, and daemon state;
- adds `--fix` repair actions for terminal-code-owned directories, verified runtime/code-server provisioning, generated profile artifacts, saved/shared shortcut decisions, and owned daemon state;
- leaves unresolved shortcut conflicts unchanged and reports them as `needs_input` with exit code `2`;
- verifies process identity before daemon repair and never signals an unverified PID;
- runs a final check pass after repairs and keeps repeated repairs idempotent;
- preserves existing SSH, serve, shortcut, import, theme, upgrade, shutdown, and path-opening routes;
- documents the command, side effects, and exit behavior;
- includes the approved design and implementation plan.

No new dependency was added.

## Tests
- `npm test` — 163 tests passed.
- `npm run typecheck` — passed for the main TypeScript project and pages project.
- Targeted doctor suite — 46 tests passed.
- `git diff --check` — passed.
- CLI smoke coverage verifies that `tode doctor --json` emits one parseable JSON document and that invalid JSON options return exit code `64`.

## Manual verification
- Built the CLI and exercised the JSON command boundary with isolated test fixtures.
- Verified check-only paths do not write managed state, download runtimes, mutate shortcut providers, signal processes, or start a daemon.
- Real `--fix` execution against a live user installation was not performed; repair behavior is covered through injected disposable fixtures and ownership checks.

## Screenshots / video
N/A — this is a CLI/runtime change with no browser-rendered UI delta.

no linked issue: no issue number was supplied for this contribution.