### PR TITLE
chore(root): pin release tooling and Node runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ concurrency:
 
 jobs:
   prepare:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.v.outputs.channel }}
@@ -28,7 +30,7 @@ jobs:
       ref: ${{ steps.v.outputs.ref }}
       flip: ${{ steps.v.outputs.flip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -66,6 +68,8 @@ jobs:
           echo "flip=${FLIP:-true}" >> "$GITHUB_OUTPUT"
 
   build:
+    permissions:
+      contents: read
     needs: prepare
     strategy:
       fail-fast: false
@@ -75,11 +79,11 @@ jobs:
         target: [darwin-arm64, linux-x64, linux-arm64]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.prepare.outputs.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -91,7 +95,7 @@ jobs:
       - name: Build
         run: scripts/release.sh "${{ needs.prepare.outputs.version }}" "${{ needs.prepare.outputs.channel }}" "${{ matrix.target }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -100,11 +104,13 @@ jobs:
           if-no-files-found: error
 
   worker:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - name: Deploy worker
@@ -115,21 +121,28 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           npm ci
-          npx wrangler deploy
+          npx --no-install wrangler@4.120.0 deploy
 
   release:
+    permissions:
+      actions: read
+      contents: write
     runs-on: ubuntu-latest
     needs: [prepare, build, worker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.prepare.outputs.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
-      - uses: actions/download-artifact@v4
+      - name: Install release tooling
+        working-directory: release-worker
+        run: npm ci
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: release-*
           merge-multiple: true

--- a/release-worker/package-lock.json
+++ b/release-worker/package-lock.json
@@ -8,7 +8,10 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260722.1",
         "typescript": "^5.5.0",
-        "wrangler": "^4.20.0"
+        "wrangler": "4.120.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/release-worker/package.json
+++ b/release-worker/package.json
@@ -1,6 +1,9 @@
 {
   "name": "tode-release-worker",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
@@ -9,6 +12,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260722.1",
     "typescript": "^5.5.0",
-    "wrangler": "^4.20.0"
+    "wrangler": "4.120.0"
   }
 }

--- a/scripts/publish-r2.sh
+++ b/scripts/publish-r2.sh
@@ -34,7 +34,7 @@ field() { node -p "require('$MANIFEST').$1"; }
 VERSION="$(field version)"
 CHANNEL="$(field channel)"
 
-wr() { (cd "$ROOT/release-worker" && npx --yes wrangler "$@"); }
+wr() { (cd "$ROOT/release-worker" && npx --no-install wrangler@4.120.0 "$@"); }
 
 put() {
   local size


### PR DESCRIPTION
## Description

This PR makes GH action versions explicit and unifies the project around `node:22`.
- https://github.com/yowainwright/terminal-code/pull/3 [proofs] 

## Why?

1. Slightly tighter security and local dev.
2. Get involved in a great product.

TY! ~Jeff