### PR TITLE
Remove kitty shortcut overrides on uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ npm-debug.log*
 # test/coverage
 coverage/
 
+# dev harnesses
+.dev-ui-sandbox/
+
 # release artifacts
 dist-release/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# terminal-code (tode) — Agent Instructions
+
+## Purpose
+
+**tode** is a CLI tool that runs VS Code inside any modern terminal by combining
+[terminal-browser](https://github.com/zenbu-labs/terminal-browser) (a browser in the
+terminal) and [code-server](https://github.com/coder/code-server) (VS Code in the
+browser). The binary is `tode`, built from this repo.
+
+## Project Layout
+
+| Path | What |
+|---|---|
+| `src/main.ts` | CLI entry point |
+| `src/bridge/` | Bridge VS Code extension that connects to the host process via IPC |
+| `src/browser/` | Browser context: preload script, main script, types |
+| `src/codeserver/` | Code-server management: server lifecycle, inject, vendored binaries |
+| `src/import/` | Import settings/keybindings/extensions from other editors |
+| `src/pages/` | React+Vite pages (shortcuts wizard, import wizard) — built separately via `TODE_PAGE` env |
+| `src/runtime/` | Runtime artifact paths and release management |
+| `src/shortcuts/` | Shortcut conflict resolution between terminal and tode |
+| `src/terminal/` | Terminal integration (OSC sequences, selection) |
+| `src/theme/` | VS Code theme generation from terminal palette |
+| `src/webui/` | Web UI utilities for pages |
+| `web/` | Marketing website (Next.js) |
+| `test/` | Test files — Node.js native test runner (`.test.js`) |
+| `scripts/` | Build, install, release scripts |
+| `assets/` | Static assets (fonts, keymaps, logos) |
+| `herdr-plugin/` | Plugin for herdr terminal |
+| `release-worker/` | Cloudflare Worker for release automation |
+
+## Build, Test, Lint Commands
+
+```bash
+npm run build          # tsc + vite build for pages
+npm run typecheck      # tsc --noEmit for src/ + pages/
+npm test               # build then node --test test/*.test.js
+npm run build:pages    # vite build for shortcuts + import pages
+```
+
+- TypeScript config: `tsconfig.json` (src/, ES2022, Node16 modules, strict)
+- Pages have their own `src/pages/tsconfig.json`
+- Test runner: Node.js built-in `node --test` — no jest/mocha
+- Vite config is `vite.config.mts` — reads `TODE_PAGE` env to build one page at a time
+
+## Architecture Rules
+
+- **Bridge ↔ Server IPC**: The bridge extension (injected into code-server) talks to
+  the host process through a Unix socket; messages are typed via `src/ipc.ts`.
+  Keep the bridge as small and dependency-free as possible (it runs inside code-server
+  and has no npm deps).
+- **No shared chunks between pages**: Each Vite page is built as a self-contained
+  bundle (one HTML, one JS, one CSS) via `TODE_PAGE` env. Never add shared chunk
+  splitting to the Vite config.
+- **Purity of terminal I/O**: The terminal render path (browser + terminal protocol)
+  must not throw on partial/flaky output. All frame parsing is best-effort.
+- **SSH**: `tode --ssh` runs the code-server backend remotely and the browser
+  frontend locally; IPC is proxied over the SSH connection.
+
+## Coding Conventions
+
+- **TypeScript**: Strict mode, `noUnusedLocals` and `noUnusedParameters` enabled.
+  Target `ES2022`, module system `Node16`.
+- **Imports**: Use Node.js built-in modules with `node:` prefix (e.g., `import path
+  from "node:path"`).
+- **Indentation**: 2 spaces, no tabs.
+- **Console/logging**: Prefer `narrateFetch` / structured logging helpers over raw
+  `console.log`. The `--timing` flag reports stage durations.
+- **Error handling**: Fatal errors exit with a user-facing message. Non-fatal errors
+  should not break the terminal session. Avoid try/catch swallowing.
+
+## Platform Constraints
+
+- **Primary targets**: macOS and Linux. No native Windows build — Windows users
+  must use WSL.
+- **Requires a terminal that supports the Kitty graphics protocol** (Ghostty, Kitty,
+  iTerm2, WezTerm, etc.).
+- **Font**: A Nerd Font is bundled and ensured at startup (`ensureFont`).
+- **VS Code theme**: Generated from the terminal's palette (OSC 4/10/11/12) so the
+  editor matches the terminal colors. See `src/theme/`.
+
+## Key Gotchas
+
+- **Shortcut conflicts**: Terminal and tode compete for keybindings. `tode --shortcut-setup`
+  resolves this via an interactive wizard. The shortcut system supports Ghostty and Kitty
+  backends — be careful not to break parsing of terminal config files.
+- **Multiple VS Code instances**: Only one code-server instance runs at a time (singleton
+  server). The IPC socket path is derived from `ipcSocketDir` in `browserglue.ts`.
+- **Version pinning**: Code-server version is pinned in `src/runtime/release.ts`
+  (`PINNED_VERSION`). When upgrading, update the vendored hash and test thoroughly.
+- **Release flow**: Release artifacts are built via `scripts/release.sh` and published
+  to Cloudflare R2 (`scripts/publish-r2.sh`), coordinated by the `release-worker/`.
+
+## Sensitive Areas — Read Before Editing
+
+- `src/bridge/extension.ts` — the VS Code extension injected into code-server; it runs
+  inside the editor process with no npm dependencies. Any import outside `node:`
+  modules will break.
+- `src/shortcuts/backends/` — parses Ghostty/Kitty config files. Incorrect parsing can
+  corrupt user config.
+- `src/runtime/release.ts` — manages the code-server binary download and version pinning.
+- `scripts/install.sh` and `scripts/dist.sh` — affect user installations.
+- `src/codeserver/inject.ts` — injects the browser glue into code-server's web UI.
+  Changes here affect all rendering.

--- a/scripts/dev-shortcuts-ui.mjs
+++ b/scripts/dev-shortcuts-ui.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Serves the shortcuts wizard UI on 127.0.0.1 with a mocked terminal backend,
+// no terminal-browser or Ghostty/kitty needed — open the printed url in any
+// browser. Decisions land in a throwaway dir via XDG overrides, so nothing on
+// this machine is touched; "apply" exercises the real session code paths.
+//
+//   node scripts/dev-shortcuts-ui.mjs
+//
+// Tweak CONFLICTS below to shape what the page shows.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const sandbox = path.join(root, ".dev-ui-sandbox");
+
+process.env.XDG_DATA_HOME = path.join(sandbox, "data");
+process.env.XDG_STATE_HOME = path.join(sandbox, "state");
+process.env.XDG_CACHE_HOME = path.join(sandbox, "cache");
+
+const { startManager } = await import(path.join(root, "dist", "shortcuts", "web.js"));
+const { managerSession, normalizeChord } = await import(
+  path.join(root, "dist", "shortcuts", "wizard.js")
+);
+
+/** What scan() reports as contested: ghostty-shaped rows. current is the
+ * action ghostty runs today; editor.command is what vscode wants instead. */
+const CONFLICTS = [
+  {
+    editorId: "ctrl+shift+c",
+    trigger: "super+shift+c",
+    current: "copy_to_clipboard",
+    editor: { means: "copy", command: "workbench.action.editor.copy" },
+    others: [],
+    inTerminal: "runs copy to clipboard in Ghostty, so copy never reaches the editor",
+    short: "copy to clipboard",
+    freed: "copy to clipboard goes",
+    tradeoff: "Ghostty's copy to clipboard stops working",
+  },
+  {
+    editorId: "ctrl+shift+v",
+    trigger: "super+shift+v",
+    current: "paste_from_clipboard",
+    editor: { means: "paste", command: "editor.action.clipboardPasteAction" },
+    others: [],
+    inTerminal: "runs paste from clipboard in Ghostty, so paste never reaches the editor",
+    short: "paste from clipboard",
+    freed: "paste from clipboard goes",
+    tradeoff: "Ghostty's paste from clipboard stops working",
+  },
+  {
+    editorId: "ctrl+shift+f",
+    trigger: "super+shift+f",
+    current: null,
+    editor: { means: "find in files", command: "workbench.action.findInFiles" },
+    others: [],
+    inTerminal: "runs what it ran before in Ghostty, so find in files never reaches the editor",
+    short: "what it ran before",
+    freed: "what it ran before goes",
+    tradeoff: "Ghostty's what it ran before stops working",
+  },
+];
+
+const TAKEN_AS = new Map([
+  ["ctrl+shift+k", "clear_screen"],
+  ["ctrl+shift+w", "close_window"],
+]);
+
+const provider = {
+  id: "mock-ghostty",
+  name: "Ghostty",
+  detect: () => true,
+  ready: () => null,
+  scan: () => CONFLICTS.map((conflict) => ({ ...conflict })),
+  takenAs: (chord) => TAKEN_AS.get(chord) ?? null,
+  trigger: (chord) => chord,
+  describe: (action) => action.replaceAll("_", " "),
+  apply: () => "",
+  onApplied: () => false,
+  undo: () => false,
+  reloadHint: () => "reload Ghostty (cmd+shift+,) or restart it for this to take effect",
+};
+
+const palette = {
+  background: [13, 15, 19],
+  foreground: [230, 233, 239],
+  ansi: [
+    [26, 27, 30], [229, 72, 77], [48, 164, 108], [245, 165, 36],
+    [93, 156, 255], [186, 148, 255], [94, 201, 227], [200, 205, 215],
+    [90, 96, 106], [255, 108, 112], [76, 194, 138], [255, 196, 84],
+    [124, 178, 255], [206, 176, 255], [126, 220, 240], [235, 238, 245],
+  ],
+};
+
+const session = managerSession(provider);
+const manager = await startManager({
+  rows: session.rows,
+  taken: session.taken,
+  normalize: normalizeChord,
+  decide: session.decide,
+  confirm: () => {
+    session.confirm();
+    return { note: `applied — ${provider.reloadHint()} (mock: nothing was reloaded)` };
+  },
+  next: async () => null,
+  continues: false,
+  reloadHint: provider.reloadHint(),
+  terminalName: provider.name,
+  palette,
+  intro: true,
+});
+
+console.log(`shortcuts ui: http://127.0.0.1:${manager.port}  (sandbox: ${sandbox})`);
+console.log("ctrl-c to stop");

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -194,7 +194,7 @@ ${STARTUP_OPEN_FILE} is a one-shot marker with the parts of an open the url cann
   data ${BROWSER_HOME.data}, state ${BROWSER_HOME.state}, cache ${BROWSER_HOME.cache},
   chromium ${BROWSER_HOME.appData}
 - \`tode --uninstall\` removes all of the above plus the install root, shim,
-  font and ghostty overrides.
+  font and ghostty/kitty overrides.
 
 ## Environment variables
 

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -17,6 +17,11 @@ import {
 } from "./runtime/paths";
 import { PINNED_VERSION } from "./runtime/release";
 import { ghosttyConfigDir, reloadGhostty, removeFreed } from "./shortcuts/backends/ghostty";
+import {
+  kittyConfigDir,
+  reloadKitty,
+  removeFreed as removeKittyFreed,
+} from "./shortcuts/backends/kitty";
 
 
 function confirm(question: string): Promise<boolean> {
@@ -109,6 +114,7 @@ export async function uninstallCommand(args: string[]): Promise<number> {
   }
 
   if (removeFreed(ghosttyConfigDir())) reloadGhostty();
+  if (removeKittyFreed(kittyConfigDir())) reloadKitty();
 
   removeFont();
 


### PR DESCRIPTION
## Summary

`tode --uninstall` only cleaned up Ghostty shortcut overrides. If the shortcut wizard had run under kitty, `tode/keybinds.kitty.conf` and its `include` line in `kitty.conf` were left behind on disk after uninstalling.

## Changes

- uninstall now also removes the kitty overrides file and strips the include line from `kitty.conf`, then live-reloads kitty when it is the parent terminal (mirrors the existing ghostty cleanup)
- `tode --skill` doc text updated to match ("ghostty/kitty overrides")
- adds an `AGENTS.md` with repo layout, build/test commands, architecture rules and sensitive areas for coding agents
- adds `scripts/dev-shortcuts-ui.mjs`, a harness that serves the shortcuts wizard UI in a regular browser against a mocked terminal provider — handy when ghostty/kitty are not installed (decisions are sandboxed under `.dev-ui-sandbox/`, now gitignored)

## Testing

- [x] `npm run typecheck` passes
- [x] `npm test` — 117 tests pass
- [x] End-to-end: ran the real `--uninstall` against a staged kitty config via `KITTY_CONFIG_DIRECTORY` + XDG overrides — override file removed, include line stripped, unrelated `kitty.conf` lines intact (fails on `main`, passes with this change)
