### PR TITLE
Fix the window is scaled up too much

### DIFF
--- a/src/browser/preload.ts
+++ b/src/browser/preload.ts
@@ -4,9 +4,11 @@ import type { PreloadCtx, ThemeMessage, TimingMessage } from "./ctx";
 declare const terminalBrowser: TerminalBrowserApi;
 
 export function preloadMain(_ctx: PreloadCtx): void {
-  const { ipcRenderer } = require("electron") as {
+  const { ipcRenderer, webFrame } = require("electron") as {
     ipcRenderer: { send(channel: string, message: unknown): void };
+    webFrame: { setZoomFactor(factor: number): void };
   };
+  webFrame.setZoomFactor(1);
   const deliver = (message: unknown) => ipcRenderer.send("tode:message", message);
 
   terminalBrowser.onTheme((theme) => {

--- a/test/browserglue.test.js
+++ b/test/browserglue.test.js
@@ -29,6 +29,14 @@ test("the preload forwards terminal themes to the main script", () => {
   assert.deepEqual(JSON.parse(JSON.stringify(sent)), [{ type: "theme", colors: theme }]);
 });
 
+test("the preload resets stale browser zoom", () => {
+  const zoomFactors = [];
+  const sandbox = workbenchSandbox([], [], zoomFactors);
+  sandbox.window = { top: {} };
+  vm.runInNewContext(preloadSource({}), sandbox);
+  assert.deepEqual(zoomFactors, [1]);
+});
+
 // The timing flow runs on real timers; an unref'd wrapper keeps the preload's
 // long 30s fallback from holding the test process open.
 const timers = {
@@ -46,7 +54,7 @@ const timers = {
   clearTimeout,
 };
 
-function workbenchSandbox(sent, classes) {
+function workbenchSandbox(sent, classes, zoomFactors = []) {
   const sandbox = {
     // the pinned build's api is theme-only — no send. Everything bound for
     // the main script leaves over electron's ipc, required by the preload.
@@ -60,6 +68,7 @@ function workbenchSandbox(sent, classes) {
             sent.push(message);
           },
         },
+        webFrame: { setZoomFactor: (factor) => zoomFactors.push(factor) },
       };
     },
     document: { documentElement: { classList: { add: (c) => classes.push(c) } } },


### PR DESCRIPTION
#2 Tode runs in a dedicated browser profile. Do not restore a stale host zoom left by a terminal resize or a previous browser session.
