### PR TITLE
Windows floor and ssh bundle fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && npm run -s build:pages",
-    "build:pages": "TODE_PAGE=shortcuts vite build && TODE_PAGE=import vite build",
+    "build:pages": "node scripts/build-pages.mjs",
     "dist": "bash scripts/dist.sh",
     "typecheck": "tsc --noEmit && tsc --noEmit -p src/pages/tsconfig.json",
     "test": "npm run -s build && node --test \"test/*.test.js\""

--- a/scripts/build-pages.mjs
+++ b/scripts/build-pages.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/* Builds each page vite knows how to build. The page is named by an
+   environment variable, which npm scripts cannot set in a way every shell
+   agrees on, so it is set here and vite is asked to build directly. */
+import { build } from "vite";
+
+for (const page of ["shortcuts", "import"]) {
+  process.env.TODE_PAGE = page;
+  await build();
+}

--- a/src/import/run.ts
+++ b/src/import/run.ts
@@ -26,7 +26,7 @@ function copyTree(from: string, to: string): boolean {
   fs.rmSync(to, { recursive: true, force: true });
   try {
     // clones rather than copies on apfs, which matters for hundreds of megabytes
-    execFileSync("cp", ["-Rc", from, to], { stdio: "ignore" });
+    fs.cpSync(from, to, { recursive: true });
     return true;
   } catch {
     try {

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -6,6 +5,7 @@ import path from "node:path";
 
 import { writeBrowserScripts } from "./browserglue";
 import { CSS_FILE } from "./codeserver/server";
+import { spawnRuntime } from "./runtime/release";
 import type { Runtime } from "./runtime/release";
 import type { TerminalPalette } from "./terminal/osc";
 
@@ -34,8 +34,8 @@ export function registerSelf(runtime: Runtime): void {
   );
   if (!fs.existsSync(bin)) return;
   try {
-    const child = spawn(
-      runtime.bin,
+    const child = spawnRuntime(
+      runtime,
       ["register-app", "--name", APP_NAME, "--id", APP_ID, "--bin", bin, "--args", "."],
       { stdio: "ignore", detached: true },
     );
@@ -65,7 +65,7 @@ export class Pane {
         JSON.stringify({ spawnedAt: Date.now(), stages: this.options.stages ?? [] }),
       );
     } catch { }
-    const child = spawn(this.runtime.bin, ["open", ...browserArgv(url, this.options)], {
+    const child = spawnRuntime(this.runtime, ["open", ...browserArgv(url, this.options)], {
       stdio: "inherit",
     });
     this.child = child;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -32,7 +32,7 @@ import {
   readPalette,
 } from "./profile";
 import { Pane, launchBrowser, registerSelf } from "./launch";
-import { resolveRuntime, resolveRuntimeWithProgress } from "./runtime/release";
+import { resolveRuntime, resolveRuntimeWithProgress, spawnRuntime } from "./runtime/release";
 import { INSTALL_ROOT } from "./runtime/paths";
 import { skillCommand } from "./skill";
 import { sshForward, sshOpen } from "./ssh";
@@ -457,7 +457,7 @@ async function shutdownCommand(): Promise<number> {
   const runtime = await resolveRuntime().catch(() => null);
   if (runtime) {
     await new Promise<void>((resolve) => {
-      const child = spawn(runtime.bin, ["shutdown"], { stdio: "ignore" });
+      const child = spawnRuntime(runtime, ["shutdown"], { stdio: "ignore" });
       child.on("error", () => resolve());
       child.on("exit", () => resolve());
     });

--- a/src/runtime/release.ts
+++ b/src/runtime/release.ts
@@ -1,7 +1,9 @@
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { BROWSER_HOME, RUNTIME_DIR, VENDOR_DIR } from "./paths";
@@ -11,7 +13,7 @@ export const PINNED_VERSION = "v0.7.6";
 const RELEASE_ORIGIN = process.env.TODE_RELEASE_ORIGIN ?? "https://terminal-browser.sh/install";
 
 const SYSTEM_INSTALL = path.join(
-  process.env.XDG_DATA_HOME ?? path.join(process.env.HOME ?? "", ".local/share"),
+  process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local/share"),
   "terminal-browser",
   "app",
 );
@@ -36,9 +38,22 @@ const VENDORED = path.join(VENDOR_DIR, "terminal-browser");
 
 export interface Runtime {
   bin: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
   root: string;
   version: string;
   source: Source;
+}
+
+export function spawnRuntime(
+  runtime: Runtime,
+  argv: string[],
+  options: SpawnOptions = {},
+): ChildProcess {
+  return spawn(runtime.bin, [...runtime.args, ...argv], {
+    ...options,
+    env: { ...process.env, ...runtime.env, ...options.env },
+  });
 }
 
 export async function lookup(version: string): Promise<Release> {
@@ -75,11 +90,12 @@ function versionAt(root: string): string | null {
 }
 
 /** Where the electron binary lives inside a terminal-browser tree. macOS ships
- * an app bundle; linux ships the bare electron layout. */
+ * an app bundle; linux and windows ship the bare electron layout. */
 export function electronEntry(root: string): string {
-  return process.platform === "darwin"
-    ? path.join(root, "electron", "terminal-browser.app", "Contents", "MacOS", "terminal-browser")
-    : path.join(root, "electron", "electron");
+  if (process.platform === "darwin") {
+    return path.join(root, "electron", "terminal-browser.app", "Contents", "MacOS", "terminal-browser");
+  }
+  return path.join(root, "electron", process.platform === "win32" ? "electron.exe" : "electron");
 }
 
 function usable(root: string, version: string): boolean {
@@ -123,6 +139,33 @@ exec "$ROOT/${electron}" "$ROOT/cli/dist/main.js" "$@"
   return bin;
 }
 
+function browserEnv(root: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    TERMINAL_BROWSER_DIST_ROOT: root,
+    ELECTRON_RUN_AS_NODE: "1",
+    XDG_DATA_HOME: process.env.TODE_BROWSER_DATA ?? BROWSER_HOME.data,
+    XDG_STATE_HOME: process.env.TODE_BROWSER_STATE ?? BROWSER_HOME.state,
+    XDG_CACHE_HOME: process.env.TODE_BROWSER_CACHE ?? BROWSER_HOME.cache,
+    TERMINAL_BROWSER_APPDATA: process.env.TODE_BROWSER_APPDATA ?? BROWSER_HOME.appData,
+  };
+  if (process.env.TODE_BROWSER_RUN) env.XDG_RUNTIME_DIR = process.env.TODE_BROWSER_RUN;
+  return env;
+}
+
+// Nothing on windows can spawn a shell script, so instead of writing one the
+// browser is started directly and told the same things through its environment.
+function startedFrom(root: string, bin?: string): Pick<Runtime, "bin" | "args" | "env"> {
+  if (process.platform !== "win32") {
+    return { bin: bin ?? writeLauncher(root), args: [], env: {} };
+  }
+  for (const dir of Object.values(BROWSER_HOME)) fs.mkdirSync(dir, { recursive: true });
+  return {
+    bin: bin ?? electronEntry(root),
+    args: [path.join(root, "cli", "dist", "main.js")],
+    env: browserEnv(root),
+  };
+}
+
 export function unpack(tarball: string, root: string) {
   const staging = `${root}.unpacking`;
   fs.rmSync(staging, { recursive: true, force: true });
@@ -138,14 +181,10 @@ function cloneTree(from: string, to: string): boolean {
   fs.rmSync(staging, { recursive: true, force: true });
   fs.mkdirSync(path.dirname(to), { recursive: true });
   try {
-    execFileSync("cp", ["-Rc", from, staging], { stdio: "ignore" });
+    fs.cpSync(from, staging, { recursive: true });
   } catch {
-    try {
-      execFileSync("cp", ["-R", from, staging], { stdio: "ignore" });
-    } catch {
-      fs.rmSync(staging, { recursive: true, force: true });
-      return false;
-    }
+    fs.rmSync(staging, { recursive: true, force: true });
+    return false;
   }
   fs.rmSync(to, { recursive: true, force: true });
   fs.renameSync(staging, to);
@@ -224,24 +263,36 @@ export async function resolveRuntime(options: ResolveOptions = {}): Promise<Runt
   if (override) {
     if (!fs.existsSync(override)) throw new Error(`TODE_TERMINAL_BROWSER_BIN is not there: ${override}`);
     const root = path.resolve(path.dirname(override), "..");
-    return { bin: override, root, version: versionAt(root) ?? "override", source: "override" };
+    return {
+      ...startedFrom(root, override),
+      root,
+      version: versionAt(root) ?? "override",
+      source: "override",
+    };
   }
 
   if (version === PINNED_VERSION && usable(VENDORED, version)) {
-    return { bin: writeLauncher(VENDORED), root: VENDORED, version, source: "vendored" };
+    return { ...startedFrom(VENDORED), root: VENDORED, version, source: "vendored" };
   }
 
   const root = rootFor(version);
   if (usable(root, version)) {
-    return { bin: writeLauncher(root), root, version, source: "pinned" };
+    return { ...startedFrom(root), root, version, source: "pinned" };
   }
 
   if (usable(SYSTEM_INSTALL, version)) {
     options.onProgress?.("cloning", 0);
     if (cloneTree(SYSTEM_INSTALL, root)) {
       options.onProgress?.("cloning", 1);
-      return { bin: writeLauncher(root), root, version, source: "cloned" };
+      return { ...startedFrom(root), root, version, source: "cloned" };
     }
+  }
+
+  if (process.platform === "win32") {
+    throw new Error(
+      "terminal-browser has no windows build to download yet — point " +
+        "TODE_TERMINAL_BROWSER_BIN at the electron binary inside one you already have",
+    );
   }
 
   const release = await lookup(version);
@@ -249,5 +300,5 @@ export async function resolveRuntime(options: ResolveOptions = {}): Promise<Runt
   unpack(tarball, root);
   fs.rmSync(tarball, { force: true });
   if (!usable(root, version)) throw new Error(`unpacked ${version} but it is missing pieces`);
-  return { bin: writeLauncher(root), root, version, source: "downloaded" };
+  return { ...startedFrom(root), root, version, source: "downloaded" };
 }

--- a/src/shortcuts/wizard.ts
+++ b/src/shortcuts/wizard.ts
@@ -1,11 +1,10 @@
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 import { builtinKeybindings, installKeybindings, readPalette, removalMasked } from "../profile";
 import type { TerminalPalette } from "../terminal/osc";
 import { DATA_DIR } from "../runtime/paths";
-import { resolveRuntimeWithProgress } from "../runtime/release";
+import { resolveRuntimeWithProgress, spawnRuntime } from "../runtime/release";
 import { extensionHolder, importedConflicts, importedHolder } from "./imported";
 import { wrap } from "./prompt";
 import { providerFor } from "./provider";
@@ -508,13 +507,9 @@ async function runManager(
     return opened.state;
   }
   const runtime = await resolveRuntimeWithProgress();
-  const child = spawn(
-    runtime.bin,
-    [
-      "open",
-      `http://127.0.0.1:${manager.port}`,
-      "--app-mode"
-    ],
+  const child = spawnRuntime(
+    runtime,
+    ["open", `http://127.0.0.1:${manager.port}`, "--app-mode"],
     { stdio: "inherit" },
   );
   void manager.done.then(() => {

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,10 +1,11 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 import { writeBrowserScripts } from "./browserglue";
 import { EXTENSIONS_DIR, USER_DIR } from "./profile";
 import { STATE_DIR } from "./runtime/paths";
+import { spawnRuntime } from "./runtime/release";
 import type { Runtime } from "./runtime/release";
 import type { TerminalPalette } from "./terminal/osc";
 
@@ -35,7 +36,7 @@ export function sshOpen(
   ];
   if (options.split) argv.push("--split", options.split);
   if (options.size) argv.push("--size", options.size);
-  const child = spawn(runtime.bin, argv, { stdio: "inherit" });
+  const child = spawnRuntime(runtime, argv, { stdio: "inherit" });
   return new Promise<number>((resolve) => {
     child.on("error", (error) => {
       process.stderr.write(`could not start terminal-browser: ${error.message}\n`);

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -99,7 +99,7 @@ fi
     "setup",
     `#!/bin/sh
 set -e
-./ensure
+sh ./ensure
 "$HOME/.local/bin/tode" --serve --prepare --palette "$(pwd)/palette.json" --import "$(pwd)/profile"
 `,
     true,
@@ -108,7 +108,7 @@ set -e
     "start",
     `#!/bin/sh
 set -e
-./ensure
+sh ./ensure
 here="$(pwd)"
 cd "$HOME"
 exec "$HOME/.local/bin/tode" --serve --palette "$here/palette.json"${

--- a/src/target.ts
+++ b/src/target.ts
@@ -18,11 +18,18 @@ export function resolveTarget(argument: string | undefined, cwd: string): Target
   return { folder: null, file: requested };
 }
 
+// A uri path is not a windows path: it is separated by forward slashes, and a
+// drive letter still follows a leading slash.
+function uriPath(file: string): string {
+  const slashed = file.replaceAll("\\", "/");
+  return slashed.startsWith("/") ? slashed : `/${slashed}`;
+}
+
 export function workbenchUrl(origin: string, target: Target): string {
   const url = new URL(origin);
   if (target.folder) url.searchParams.set("folder", target.folder);
   if (target.file) {
-    const uri = `vscode-remote://${url.host}${target.file}`;
+    const uri = `vscode-remote://${url.host}${uriPath(target.file)}`;
     url.searchParams.set("payload", JSON.stringify([["openFile", uri]]));
   }
   return url.toString();

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { DEFAULT_INSTALL_ROOT, INSTALL_ROOT, STATE_DIR } from "./runtime/paths";
@@ -162,7 +163,7 @@ export async function upgrade(options: UpgradeOptions = {}): Promise<Outcome> {
   writeReceipt(build);
 
   const shim = path.join(
-    process.env.XDG_BIN_HOME ?? path.join(process.env.HOME ?? "", ".local", "bin"),
+    process.env.XDG_BIN_HOME ?? path.join(os.homedir(), ".local", "bin"),
     "tode",
   );
   const shipped = path.join(INSTALL_ROOT, "bin", "tode");


### PR DESCRIPTION
This is the tode/terminal-code half of Windows support, paired with terminal-browser#96.

Same reason as the other PR. I'm on Windows and wanted tode working here instead of through WSL.

Same big thing to agree on. The daemon can't reach your terminal on Windows, so this spawns the browser directly in the foreground instead of through the generated shell launcher. Windows can't run shell scripts, and node won't spawn .cmd files without shell:true anymore. Unix keeps using the same launcher script as before, unchanged.

I watched `tode --ssh <host>` actually connect and draw a remote workbench in a native Windows console. That's the thing this PR makes possible, paired with the browser PR.

What doesn't work is full local `tode <path>` on Windows, because coder doesn't publish a Windows code-server build and I haven't built one myself. This PR only gets the --ssh path working.

Two commits. Same openness to splitting this up as I said on the browser PR.
